### PR TITLE
Opinion filters

### DIFF
--- a/@client/collapsed_proposal.coffee
+++ b/@client/collapsed_proposal.coffee
@@ -27,10 +27,6 @@ window.CollapsedProposal = ReactiveComponent
     col_sizes = column_sizes
                   width: @props.width
 
-    # we want to update if the sort order changes so that we can 
-    # resolve @local.keep_in_view
-    fetch("cluster-#{slugify(proposal.cluster or 'Proposals')}-sort_order")
-
     current_user = fetch '/current_user'
 
     watching = current_user.subscriptions[proposal.key] == 'watched'
@@ -83,7 +79,7 @@ window.CollapsedProposal = ReactiveComponent
                                            # with letter. seeking to hash was failing 
                                            # on proposals whose name began with number.
       style: _.defaults {}, (@props.wrapper_style or {}),
-        minHeight: 64
+        minHeight: 84
         position: 'relative'
         margin: "0 0 #{if can_edit then '0' else '15px'} 0"
         padding: 0
@@ -301,7 +297,7 @@ window.CollapsedProposal = ReactiveComponent
         style: 
           display: 'inline-block' 
           position: 'relative'
-          top: 4
+          top: -26
           verticalAlign: 'top'
           width: col_sizes.second
           marginLeft: col_sizes.gutter
@@ -313,9 +309,11 @@ window.CollapsedProposal = ReactiveComponent
           opinions: opinions
           width: col_sizes.second
           height: 40
-          enable_selection: false
+          enable_individual_selection: true
+          enable_range_selection: true
           draw_base: true
           draw_base_labels: !slider_regions
+          selection_state: 'filtered'
 
         Slider 
           base_height: 0
@@ -330,7 +328,7 @@ window.CollapsedProposal = ReactiveComponent
           handle_height: 18
           handle_width: 21
           handle_style: 
-            opacity: if !browser.is_mobile && @local.hover_proposal != proposal.key && !@local.slider_has_focus then 0 else 1             
+            opacity: if fetch('filtered').current_filter?.label != "just you" && !browser.is_mobile && @local.hover_proposal != proposal.key && !@local.slider_has_focus then 0 else 1             
           offset: true
           handle_props:
             use_face: false
@@ -366,17 +364,6 @@ window.CollapsedProposal = ReactiveComponent
               update.dummy = !update.dummy
               save update
 
-              @local.keep_in_view = 
-                offset: prev_offset
-                scroll: prev_scroll
-
-              scroll_handle = => 
-                @local.keep_in_view = null 
-                window.removeEventListener 'scroll', scroll_handle
-
-              window.addEventListener 'scroll', scroll_handle
-
-
             mouse_over_element = closest e.target, (node) => 
               node == @getDOMNode()
 
@@ -388,7 +375,7 @@ window.CollapsedProposal = ReactiveComponent
       if show_proposal_scores
         score = 0
         filter_out = fetch 'filtered'
-        opinions = (o for o in opinions when !filter_out.users?[o.user])
+        opinions = (o for o in opinions when filter_out.enable_comparison || !filter_out.users?[o.user])
 
         for o in opinions 
           score += o.stance
@@ -448,30 +435,3 @@ window.CollapsedProposal = ReactiveComponent
               "{num_opinions, plural, =0 {<small>no opinions</small>} one {# <small>opinion</small>} other {# <small>opinions</small>} }"
 
 
-  componentDidUpdate: -> 
-    if @local.keep_in_view
-      prev_scroll = @local.keep_in_view.scroll
-      prev_offset = @local.keep_in_view.offset
-
-      target = prev_scroll + @getDOMNode().offsetTop - prev_offset
-      if window.scrollTo && window.scrollY != target
-        window.scrollTo(0, target)
-        @local.keep_in_view = null
-
-    if @local.slid && !@fading 
-      @fading = true
-
-      update_bg = => 
-        if @local.slid <= 0
-          @getDOMNode().style.backgroundColor = ''
-          clearInterval int
-          @fading = false
-        else 
-          @getDOMNode().style.backgroundColor = "rgba(253, 254, 216, #{@local.slid / 1000})"
-
-      int = setInterval =>
-        @local.slid -= 50
-        update_bg() 
-      , 50
-
-      update_bg()

--- a/@client/collapsed_proposal.coffee
+++ b/@client/collapsed_proposal.coffee
@@ -309,8 +309,8 @@ window.CollapsedProposal = ReactiveComponent
           opinions: opinions
           width: col_sizes.second
           height: 40
-          enable_individual_selection: true
-          enable_range_selection: true
+          enable_individual_selection: !browser.is_mobile
+          enable_range_selection: !browser.is_mobile
           draw_base: true
           draw_base_labels: !slider_regions
           selection_state: 'filtered'

--- a/@client/drop_menu.coffee
+++ b/@client/drop_menu.coffee
@@ -1,0 +1,238 @@
+
+
+# DropMenu
+
+# structure: 
+
+#   DropMenu
+
+#     Wrapper
+
+#       Anchor (triggers menu open)
+
+#       Menu (a list)
+
+#         Option
+
+#         (...)
+
+
+# props: 
+
+#   open_menu_on (focus | activation)  (common case is hover vs click) 
+
+#   wrapper_style
+#   anchor_style
+#   anchor_when_open_style
+#   menu_style
+#   option_style
+#   active_option_style
+
+#   selection_made_callback (option) -> 
+
+#   options [{}, {}]   # each option needs a label. Structure will be LI -> A. If href is present, will be added to A
+#   render_option (option, is_active) -> 
+#   render_anchor -> 
+
+# state: 
+#   - open
+#   - active_option ("focus" in other code)
+
+
+window.DropMenu = ReactiveComponent
+  displayName: 'DropMenu'
+
+  render : ->
+
+    open_menu_on = @props.open_menu_on or 'focus' #other option is 'activation'
+
+    wrapper_style = _.defaults {}, @props.wrapper_style, 
+      position: 'relative'
+
+    anchor_style = _.defaults {}, @props.anchor_style,
+      position: 'relative'
+      background: 'transparent'
+      border: 'none'
+      cursor: 'pointer'
+      fontSize: 'inherit'
+
+    anchor_when_open_style = _.defaults {}, @props.anchor_open_style, anchor_style
+    
+    menu_style = _.defaults {}, @props.menu_style,
+      listStyle: 'none'
+      position: 'absolute'
+      zIndex: 999999
+
+    menu_when_open_style = _.defaults {}, @props.menu_when_open_style, menu_style
+
+
+    option_style = _.defaults {}, @props.option_style,
+      cursor: 'pointer'
+      outline: 'none'
+    active_option_style = _.defaults {}, @props.active_option_style, option_style
+
+    options = @props.options
+
+    render_anchor = @props.render_anchor
+    render_option = @props.render_option
+
+    set_active = (idx) => 
+      idx = 0 if !idx?
+      @local.active_option = idx 
+      save @local 
+      setTimeout => 
+        @refs["menuitem-#{idx}"].getDOMNode().focus()
+      , 0
+
+
+    trigger = (e) => 
+      selection = options[@local.active_option]
+
+      @props.selection_made_callback? selection
+
+      if selection.href 
+        e.currentTarget.click()
+
+      close_menu()
+      e.stopPropagation()
+      e.preventDefault()
+
+
+    close_menu = => 
+      document.activeElement.blur()
+      @local.show_menu = false
+      save @local
+
+    # wrapper
+    DIV 
+      ref: 'menu_wrap'
+      key: 'dropmenu-wrapper'
+      style: wrapper_style
+
+      onTouchEnd: => 
+        @local.show_menu = !@local.show_menu
+        save @local
+
+      onMouseLeave: close_menu
+
+      onBlur: (e) => 
+        setTimeout => 
+          # if the focus isn't still on an element inside of this menu, 
+          # then we should close the menu
+          if @refs.menu_wrap && $(document.activeElement).closest(@refs.menu_wrap?.getDOMNode()).length == 0
+            @local.sort_menu = false; save @local
+        , 0
+
+      onKeyDown: (e) => 
+        if e.which == 13 || e.which == 32 || e.which == 27 # ENTER or ESC
+          close_menu()
+          e.preventDefault()            
+        else if e.which == 38 || e.which == 40 # UP / DOWN ARROW
+          @local.active_option = -1 if !@local.active_option?
+          if e.which == 38
+            @local.active_option--
+            if @local.active_option < 0 
+              @local.active_option = options.length - 1
+          else 
+            @local.active_option++
+            if @local.active_option > options.length - 1
+              @local.active_option = 0 
+          set_active @local.active_option
+          e.preventDefault() # prevent window from scrolling too
+
+
+      # anchor
+
+      BUTTON 
+        tabIndex: 0
+        'aria-haspopup': "true"
+        'aria-owns': "dropMenu-#{@local.key}"
+        style: if @local.show_menu then anchor_when_open_style else anchor_style
+
+
+        onMouseEnter: if open_menu_on == 'focus' then (e) => 
+                @local.show_menu = true
+                set_active(0)
+                save @local 
+
+        onClick: if open_menu_on != 'focus' then (e) => 
+                @local.show_menu = !@local.show_menu
+                set_active(0) if @local.show_menu
+                save @local
+
+        onKeyDown: (e) => 
+          if e.which == 13 || e.which == 32  
+            @local.show_menu = !@local.show_menu
+            if @local.show_menu
+              set_focus(0) 
+            save @local
+            e.preventDefault()
+            e.stopPropagation() 
+
+        render_anchor @local.show_menu 
+
+      # drop menu
+
+      UL
+        id: "dropMenu-#{@local.key}" 
+        role: "menu"
+        'aria-hidden': !@local.show_menu
+        hidden: !@local.show_menu
+        style: if @local.show_menu then menu_when_open_style else menu_style
+
+
+
+        for option, idx in options
+          do (option, idx) =>
+            LI 
+              key: option.label
+              role: "presentation"
+
+              A
+                ref: "menuitem-#{idx}"
+                role: "menuitem"
+                tabIndex: if @local.active_option == idx then 0 else -1
+                href: option.href #optional
+                key: "#{option.label}-activate" 
+                'data-action': option['data-action'] #optional
+                
+                style: if @local.active_option == idx then active_option_style else option_style
+
+                onClick: (e) => 
+                  if @local.active_option != idx 
+                    set_active idx 
+                  trigger(e)
+
+                onTouchEnd: (e) =>
+                  if @local.active_option != idx 
+                    set_active idx 
+                  trigger(e)
+
+                onKeyDown: (e) => 
+                  if e.which == 13 || e.which == 32 # ENTER or SPACE
+                    trigger(e)
+
+                onFocus: (e) => 
+                  if @local.active_option != idx 
+                    set_active idx
+                  e.stopPropagation()
+
+                onMouseEnter: => 
+                  if @local.active_option != idx                         
+                    set_active idx
+
+                onBlur: (e) => 
+                  @local.active_option = null 
+                  save @local  
+
+                onMouseExit: (e) => 
+                  @local.active_option = null 
+                  save @local
+                  e.stopPropagation()
+
+                render_option option, @local.active_option == idx
+
+                  
+
+
+

--- a/@client/filter.coffee
+++ b/@client/filter.coffee
@@ -557,6 +557,7 @@ OpinionFilter = ReactiveComponent
     filter_out = fetch 'filtered'
     users = fetch '/users' # fetched here so its ready for toggle_filter func
 
+    return DIV null if !users.users
     filters_for_admin = customization('opinion_filters_admin_only') 
     custom_filters = customization 'opinion_filters'
     
@@ -576,7 +577,16 @@ OpinionFilter = ReactiveComponent
       filters = filters.concat custom_filters
 
     if !filter_out.current_filter
-      filter_out.current_filter = filters[0]
+      dfault = customization('opinion_filters_default') or 'everyone'
+      initial_filter = null 
+      for filter in filters 
+        if filter.label == dfault 
+          initial_filter = filter 
+          break 
+
+      initial_filter ||= filters[0]
+
+      toggle_filter initial_filter
 
     current_filter = filter_out.current_filter
 
@@ -597,7 +607,7 @@ OpinionFilter = ReactiveComponent
             fontSize: 20
             position: 'relative'
 
-          if current_filter.label in ['everyone', 'just you']
+          if current_filter?.label in ['everyone', 'just you']
             TRANSLATE "engage.opinion_filter.label", 'show opinion of' 
           else 
             TRANSLATE "engage.opinion_filter.label_short", 'showing'
@@ -613,7 +623,7 @@ OpinionFilter = ReactiveComponent
 
             render_anchor: ->
               
-              key = if current_filter.label not in ['everyone', 'just you'] then "/translations/#{fetch('/subdomain').name}" else null
+              key = if current_filter?.label not in ['everyone', 'just you'] then "/translations/#{fetch('/subdomain').name}" else null
               SPAN 
                 style: 
                   fontWeight: 'bold'      

--- a/@client/filter.coffee
+++ b/@client/filter.coffee
@@ -389,7 +389,7 @@ SortProposalsMenu = ReactiveComponent
     SPAN
       style: 
         color: 'black'
-        fontSize: 14
+        fontSize: 20
 
       TRANSLATE "engage.sort_by", "sort by"
 
@@ -412,6 +412,7 @@ SortProposalsMenu = ReactiveComponent
             SPAN style: _.extend cssTriangle 'bottom', focus_color(), 8, 5,
               display: 'inline-block'
               marginLeft: 4   
+              marginBottom: 2
 
         render_option: (option, is_active) -> 
           [        
@@ -576,6 +577,8 @@ OpinionFilter = ReactiveComponent
     if !filter_out.current_filter
       filter_out.current_filter = filters[0]
 
+    current_filter = filter_out.current_filter
+
     DIV 
       style: (@props.style or {})
       className: 'filter_opinions_to'
@@ -585,81 +588,114 @@ OpinionFilter = ReactiveComponent
           marginTop: 0
           lineHeight: 1
 
-        INPUT 
-          type: 'checkbox'
-          id: 'enable_comparison'
-          checked: filter_out.enable_comparison
-          ref: 'enable_comparison'
-          onChange: => 
-            set_comparison_mode @refs.enable_comparison.getDOMNode().checked
-
-        LABEL 
-          htmlFor: 'enable_comparison'
-          TRANSLATE 'engage.compare_all', "Compare to all"
-
-        SPAN
-          style: 
-            fontSize: 14
-            #fontWeight: 600
-            color: '#777'
-
-          TRANSLATE "engage.opinion_filter.label", 'Filter to:' 
-
         if fetch('/subdomain').name in ['bitcoin', 'bitcoinclassic']
           VerificationProcessExplanation()
 
-        for filter,idx in filters 
-          do (filter, idx) => 
-            show_tooltip = => 
-              @local.focus = idx
-              save @local
-              if filter.tooltip 
-                tooltip = fetch 'tooltip'
-                tooltip.coords = $(@refs["filter-#{idx}"].getDOMNode()).offset()
-                tooltip.tip = filter.tooltip
-                save tooltip
+        DIV
+          style: 
+            fontSize: 20
+            #fontWeight: 600
+            position: 'relative'
 
-            hide_tooltip = => 
-              @local.focus = null
-              save @local            
-              if filter.tooltip 
-                tooltip = fetch 'tooltip'
-                tooltip.coords = tooltip.tip = null 
-                save tooltip
+          TRANSLATE "engage.opinion_filter.label", 'show opinion of:' 
+          
+          " "
 
-            is_enabled = filter_out.current_filter?.label == filter.label
-            BUTTON 
-              'aria-label': translator {id: "engage.opinion_filter.explanation", label: filter.label}, "Filter opinions to {label}"
-              'aria-describedby': if filter.tooltip then 'tooltip'
-              'aria-pressed': is_enabled
-              tabIndex: 0
-              ref: "filter-#{idx}"
+          DropMenu
+            options: filters
+
+            open_menu_on: 'activation'
+
+            selection_made_callback: toggle_filter
+
+            render_anchor: ->
+              
+              key = if current_filter.label not in ['everyone' or 'just you'] then "/translations/#{fetch('/subdomain').name}" else null
+              SPAN null,
+
+                translator 
+                  id: "opinion_filter.name.#{current_filter.label}"
+                  key: key
+                  current_filter.label
+
+                SPAN style: _.extend cssTriangle 'bottom', focus_color(), 8, 5,
+                  display: 'inline-block'
+                  marginLeft: 4  
+                  marginBottom: 2 
+
+            render_option: (filter, is_active) -> 
+              [        
+                translator 
+                  id: "opinion_filter.name.#{filter.label}"
+                  key: "/translations/#{fetch('/subdomain').name}"
+                  filter.label
+
+                if filter.tooltip
+                  SPAN 
+                    style: 
+                      fontSize: 12
+                      color: if is_active then 'white' else 'black'
+                      marginLeft: 16
+                      verticalAlign: 'baseline'
+
+                    filter.tooltip
+              ]
+
+            wrapper_style: 
+              display: 'inline-block'
+
+            anchor_style: 
+              fontWeight: 600
+              padding: 0
+              display: 'inline-block'
+              color: focus_color() #'inherit'
+              textTransform: 'lowercase'
+              borderRadius: 16
+
+            menu_style: 
+              minWidth: 250
+              backgroundColor: '#eee'
+              border: "1px solid #{focus_color()}"
+              left: 'auto'
+              right: -9999
+              top: 18
+              borderRadius: 8
+              fontWeight: 400
+              overflow: 'hidden'
+              boxShadow: '0 1px 2px rgba(0,0,0,.3)'
+              textAlign: 'right'
+
+            menu_when_open_style: 
+              right: 0
+
+            option_style: 
+              padding: '6px 12px'
+              borderBottom: "1px solid #ddd"
+              display: 'block'
+
+            active_option_style: 
+              color: 'white'
+              backgroundColor: focus_color()
+
+          if current_filter.label != 'everyone'
+            DIV 
               style: 
-                display: 'inline-block'
-                marginLeft: 7
-                padding: '0 3px 0 3px'  
-                color: if is_enabled then 'white' else if @local.focus == idx then 'black' else '#777'
-                cursor: 'pointer'
+                position: 'absolute'
+                right: 0 
+                bottom: -20
                 fontSize: 14
-                backgroundColor: if is_enabled then focus_color() else if @local.focus == idx then '#eee' else 'transparent'
-                border: 'none'
-                outline: 'none'
+                zIndex: 99
+              INPUT 
+                type: 'checkbox'
+                id: 'enable_comparison'
+                checked: filter_out.enable_comparison
+                ref: 'enable_comparison'
+                onChange: => 
+                  set_comparison_mode @refs.enable_comparison.getDOMNode().checked
 
-              onMouseEnter: show_tooltip
-              onMouseLeave: hide_tooltip
-              onFocus: show_tooltip
-              onBlur: hide_tooltip 
-              onClick: -> toggle_filter(filter)   
-              onKeyDown: (e) -> 
-                if e.which == 13 || e.which == 32 # ENTER or SPACE
-                  toggle_filter(filter) 
-                  e.preventDefault()
-                  e.stopPropagation()
-
-              translator 
-                id: "opinion_filter.name.#{filter.label}"
-                key: "/translations/#{fetch('/subdomain').name}"
-                filter.label
+              LABEL 
+                htmlFor: 'enable_comparison'
+                TRANSLATE 'engage.compare_all', "compare to everyone"
 
 
 VerificationProcessExplanation = ReactiveComponent

--- a/@client/franklin.coffee
+++ b/@client/franklin.coffee
@@ -239,20 +239,24 @@ Proposal = ReactiveComponent
               marginBottom: 8
               marginTop: 48
 
-            TRANSLATE
-              id: "engage.opinion_header"
-              'What do you think?'
+            if mode == 'crafting'
+              TRANSLATE
+                id: "engage.opinion_header"
+                'What do you think?'
+            else 
+              TRANSLATE
+                  id: "engage.opinion_header_results"
+                  'What do we think?'
 
 
-        if customization('opinion_filters')
-          DIV 
+        DIV 
+          style: 
+            position: 'relative'
+            width: BODY_WIDTH()
+            margin: '8px auto 20px auto'
+          OpinionFilter
             style: 
-              position: 'relative'
-              width: BODY_WIDTH()
-              margin: '8px auto 20px auto'
-            OpinionFilter
-              style: 
-                textAlign: 'center'
+              textAlign: 'center'
 
         if is_loading
           LOADING_INDICATOR
@@ -284,7 +288,8 @@ Proposal = ReactiveComponent
               opinions: opinionsForProposal(@proposal)
               width: PROPOSAL_HISTO_WIDTH()
               height: if fetch('histogram-dock').docked then 50 else 170
-              enable_selection: true
+              enable_individual_selection: true
+              enable_range_selection: true
               draw_base: if fetch('histogram-dock').docked then true else false
               backgrounded: mode == 'crafting'
               draw_base: true
@@ -1490,7 +1495,7 @@ buildPointsList = (proposal, valence, sort_field, filter_included) ->
 
 
   # filter out filter users...
-  filtered_out = fetch('filtered')
+  filtered_out = fetch 'filtered'
   if filtered_out.users
     filtered = true
     opinions = (o for o in opinions when !(filtered_out.users?[o.user]))
@@ -2134,11 +2139,11 @@ LocationTransition = ReactiveComponent
       else if auth.form
         reset_key auth
 
-      # hist = fetch(namespaced_key('histogram', @proposal))
-      # if hist.selected_opinion || hist.selected_opinions || hist.selected_opinion_value
-      #   hist.selected_opinion = hist.selected_opinions = hist.selected_opinion_value = null
-      #   save hist
       #######
+
+      if loc.url == '/'
+        reset_selection_state('filtered')
+
 
       @last_location = loc.url
     SPAN null
@@ -2421,14 +2426,13 @@ Root = ReactiveComponent
         delete loc.query_params.selected
         save loc
 
-      else if hist.selected_opinions || hist.selected_opinion
-        if hist.dragging
-          hist.dragging = false
-        else
-          hist.selected_opinion = null
-          hist.selected_opinions = null
-          hist.selected_opinion_value = null
-        save hist
+      else if hist.selected_opinions || hist.selected_opinion || hist.originating_histogram
+        reset_selection_state hist 
+
+    if !fetch('auth').form && loc.url == '/'
+      hist = fetch 'filtered'
+      if hist.selected_opinions || hist.selected_opinion || hist.originating_histogram
+        reset_selection_state hist
 
 
     wysiwyg_editor = fetch 'wysiwyg_editor'

--- a/@client/franklin.coffee
+++ b/@client/franklin.coffee
@@ -236,7 +236,6 @@ Proposal = ReactiveComponent
               fontWeight: 700
               fontStyle: 'oblique'
               textAlign: 'center'
-              marginBottom: 8
               marginTop: 48
 
             if mode == 'crafting'
@@ -253,10 +252,19 @@ Proposal = ReactiveComponent
           style: 
             position: 'relative'
             width: BODY_WIDTH()
-            margin: '8px auto 20px auto'
+            margin: '0px auto 20px auto'
+
           OpinionFilter
             style: 
               textAlign: 'center'
+            enable_comparison_wrapper_style: 
+              # position: 'absolute'
+              # right: 0 
+              # bottom: -20
+              fontSize: 14
+              marginTop: 4
+              # zIndex: 99
+
 
         if is_loading
           LOADING_INDICATOR

--- a/@client/franklin.coffee
+++ b/@client/franklin.coffee
@@ -216,6 +216,8 @@ Proposal = ReactiveComponent
 
     is_loading = !page.proposal || !@proposal.name?
 
+    just_you = fetch('filtered').current_filter?.label == 'just you'
+
     ARTICLE 
       id: "proposal-#{@proposal.id}"
       key: @props.slug
@@ -238,7 +240,7 @@ Proposal = ReactiveComponent
               textAlign: 'center'
               marginTop: 48
 
-            if mode == 'crafting'
+            if mode == 'crafting' || just_you
               TRANSLATE
                 id: "engage.opinion_header"
                 'What do you think?'
@@ -408,9 +410,11 @@ Proposal = ReactiveComponent
                   points: buildPointsList \
                     @proposal, 'cons', \
                     (if mode == 'results' then 'score' else 'last_inclusion'), \ 
-                    mode == 'crafting' && !TWO_COL()
+                    mode == 'crafting' && !TWO_COL(), \
+                    mode == 'crafting' || TWO_COL() || !just_you
                   style: 
                     visibility: if !TWO_COL() && !has_community_points then 'hidden'
+
 
                 #community pros
                 PointsList 
@@ -423,7 +427,8 @@ Proposal = ReactiveComponent
                   points: buildPointsList \
                     @proposal, 'pros', \
                     (if mode == 'results' then 'score' else 'last_inclusion'), \ 
-                    mode == 'crafting' && !TWO_COL()
+                    mode == 'crafting' && !TWO_COL(), \
+                    mode == 'crafting' || TWO_COL() || !just_you
                   style: 
                     visibility: if !TWO_COL() && !has_community_points then 'hidden'
 
@@ -1496,7 +1501,7 @@ GroupSelectionRegion = ReactiveComponent
 
 
 
-buildPointsList = (proposal, valence, sort_field, filter_included) ->
+buildPointsList = (proposal, valence, sort_field, filter_included, show_all_points) ->
   sort_field = sort_field or 'score'
   points = fetch("/page/#{proposal.slug}").points or []
   opinions = fetch(proposal).opinions
@@ -1504,7 +1509,7 @@ buildPointsList = (proposal, valence, sort_field, filter_included) ->
 
   # filter out filter users...
   filtered_out = fetch 'filtered'
-  if filtered_out.users
+  if filtered_out.users && !show_all_points
     filtered = true
     opinions = (o for o in opinions when !(filtered_out.users?[o.user]))
 

--- a/@client/histogram.coffee
+++ b/@client/histogram.coffee
@@ -27,8 +27,12 @@ require './browser_hacks'
 #   opinions
 #     The opinions to show in the histogram. 
 #   width, height
-#   enable_selection (default = false)
-#     Whether users can select opinions segments on the histogram
+#   enable_individual_selection (default = false)
+#     Whether individual users can be selected on the histogram
+#   enable_range_selection (default = false)
+#     Whether ranges can be selected on the histogram
+#   selection_state (default = @props.key)
+#     The statebus key at which selection state will be updated
 #   draw_base (default = false)
 #     Whether to draw a base with +/- labels. If a slider is attached,
 #     don't need the labels.
@@ -90,15 +94,10 @@ require './browser_hacks'
 #      Array of opinion keys defining the current set of selected opinions. 
 #   selected_opinion_value
 #      The opinion value around which the current selection is defined  
-#   region_selection_width
-#      The width of the opinion selection region. 
 #   highlighted_users
 #      Users that other components want to have highlighted in the 
 #      histogram. In the render, this is intersected with the users whose 
 #      opinions are selected to determine which avatars are highlighted. 
-#   dragging
-#      Whether the user is currently dragging the mouse through the
-#      histogram. 
 #
 # Local state: 
 #   simulation_opinion_hash
@@ -107,17 +106,11 @@ require './browser_hacks'
 #   mouse_opinion_value
 #      Stores the mapped opinion value of the current mouse position
 #      within the histogram. 
-#   last_selection_via_drag
-#      Whether the last time the selection region moved was done by dragging
-#      in the histogram. This is used to resolve a technicality with 
-#      the order in which mouseUp and mouseClick events are fired. 
 #   avatar_size
 #      The base size of the avatars, as determined by the physics 
 #      simulation. This piece of state would be local, but it needs
 #      to be settable from the physics simulation.
-#   mouse_x_of_last_resize
-#      Stores last mouse position when in selection area resize mode.
-#
+
 # Accessibility notes: 
 #   - histogram itself should be tabbable. Should summarize results. 
 #   - pressing enter should make avatars navigable via tabbing keys. state is @local.navigating_inside
@@ -129,28 +122,43 @@ require './browser_hacks'
 # require './vendor/d3.v3.min'
 require './shared'
 
+# REGION_SELECTION_WIDTH controls the size of the selection region when 
+# hovering over the histogram. It defines the opinion bounds within which 
+# opinions are selected. Opinions = [-1, 1]. REGION_SELECTION_WIDTH is 
+# on this scale. 
+REGION_SELECTION_WIDTH = .25
+
+# Controls the size of the vertical space at the top of 
+# the histogram that gives some space for users to hover over 
+# the most populous areas
+REGION_SELECTION_VERTICAL_PADDING = 30
+
+window.reset_selection_state = (state) ->
+  hist = fetch state
+  _.extend hist,
+    initialized: true
+    highlighted_users : null
+    
+    selected_opinion : null
+    selected_opinions : null 
+      # use null instead of [] because an empty selection of []
+      # is treated differently than no selection whatsoever
+    selected_opinion_value : null
+    originating_histogram : null
+  save hist
+
+
 window.Histogram = ReactiveComponent
   displayName : 'Histogram'
 
+  get_hist_state: -> fetch (@props.selection_state or @props.key)
+
   render: -> 
-    hist = fetch @props.key
-    filter_out = fetch 'filtered'
+    hist = @get_hist_state()
 
     dirtied = false 
     if !hist.initialized
-      _.defaults hist,
-        initialized: true
-        highlighted_users : null
-        # region_selection_width controls the size of the selection region when 
-        # hovering over the histogram. It defines the opinion bounds within which 
-        # opinions are selected. Opinions = [-1, 1]. region_selection_width is 
-        # on this scale. 
-        region_selection_width : .25
-        selected_opinion : null
-        selected_opinions : null 
-          # use null instead of [] because an empty selection of []
-          # is treated differently than no selection whatsoever
-      save hist
+      reset_selection_state(hist)
       dirtied = true 
 
     avatar_radius = calculateAvatarRadius(@props.width, @props.height, @props.opinions)
@@ -173,29 +181,24 @@ window.Histogram = ReactiveComponent
 
     @local.dirty == dirtied
 
-    #return SPAN null if dirtied
-
     if !@props.draw_base_labels?
       @props.draw_base_labels = true
 
-    @props.enable_selection &&= @props.opinions.length > 0
+    filter_out = fetch 'filtered'
+    opinions = (o for o in @props.opinions when filter_out.enable_comparison || !filter_out.users?[o.user])
 
-    # Controls the size of the vertical space at the top of 
-    # the histogram that gives some space for users to hover over 
-    # the most populous areas
-    region_selection_vertical_padding = if @props.enable_selection then 30 else 0
-    if @local.region_selection_vertical_padding != region_selection_vertical_padding
-       @local.region_selection_vertical_padding = region_selection_vertical_padding
+    @props.enable_individual_selection &&= opinions.length > 0
+    @props.enable_range_selection &&= opinions.length > 1
 
     # whether to show the shaded opinion selection region in the histogram
-    draw_selection_area = @props.enable_selection &&
+    draw_selection_area = @props.enable_range_selection &&
                             !hist.selected_opinion && 
                             !@props.backgrounded &&
                             (hist.selected_opinions || 
                               (!@local.touched && 
                                 @local.mouse_opinion_value && 
                                 !@local.hoving_over_avatar))
-
+    histo_height = @props.height + (if true || @props.enable_range_selection then REGION_SELECTION_VERTICAL_PADDING else 0)
     histogram_props = 
       tabIndex: if !@props.backgrounded then 0
 
@@ -206,7 +209,7 @@ window.Histogram = ReactiveComponent
 
       style: css.crossbrowserify
         width: @props.width
-        height: @props.height + @local.region_selection_vertical_padding
+        height: histo_height
         position: 'relative'
         borderBottom: if @props.draw_base then @props.base_style or "1px solid #999"
         #visibility: if @props.opinions.length == 0 then 'hidden'
@@ -237,8 +240,6 @@ window.Histogram = ReactiveComponent
         , 0
 
     score = 0
-    filter_out = fetch 'filtered'
-    opinions = (o for o in @props.opinions when !filter_out.users?[o.user])
     for o in opinions 
       score += o.stance
     avg = score / opinions.length
@@ -254,14 +255,14 @@ window.Histogram = ReactiveComponent
       exp = translator "engage.slider_feedback.neutral", "Neutral"
 
 
-    if @props.enable_selection
+    if @props.enable_range_selection || @props.enable_individual_selection
       if !browser.is_mobile
         _.extend histogram_props,
           onClick: @onClick
           onMouseMove: @onMouseMove
           onMouseLeave: @onMouseLeave
-          onMouseUp: @onMouseUp
           onMouseDown: @onMouseDown
+
       else 
         _.extend histogram_props,
 
@@ -281,14 +282,8 @@ window.Histogram = ReactiveComponent
           onTouchEnd: (ev) => 
             curr_time = new Date().getTime()
             # activation by double tap
-            if @local.last_tapped_at && curr_time - @local.last_tapped_at < 300          
-              ev.preventDefault()
-              @onMouseUp(ev)
-            else 
-              @local.last_tapped_at = curr_time
-              save @local
-
-          onTouchCancel: (ev) => ev.preventDefault(); @onMouseUp(ev)
+            @local.last_tapped_at = curr_time
+            save @local
 
     DIV histogram_props, 
       DIV 
@@ -319,7 +314,7 @@ window.Histogram = ReactiveComponent
       if @props.draw_base_labels
         @drawHistogramLabels()
 
-      if @props.enable_selection
+      if true || @props.enable_range_selection
         # A little padding at the top to give some space for selecting
         # opinion regions with lots of people stacked high      
         DIV style: {height: @local.region_selection_vertical_padding}
@@ -332,7 +327,7 @@ window.Histogram = ReactiveComponent
 
       DIV 
         style: 
-          height: @props.height
+          paddingTop: histo_height - @props.height 
 
         HistoAvatars
           dirtied: dirtied
@@ -340,7 +335,7 @@ window.Histogram = ReactiveComponent
           selected_opinion: hist.selected_opinion 
           selected_opinions: hist.selected_opinions
           avatar_size: @local.avatar_size 
-          enable_selection: @props.enable_selection
+          enable_selection: @props.enable_individual_selection
           proposal: @props.proposal
           height: @props.height 
           backgrounded: @props.backgrounded
@@ -374,54 +369,46 @@ window.Histogram = ReactiveComponent
     ]
 
   drawSelectionArea: -> 
-    hist = fetch @props.key
+    hist = @get_hist_state()
     anchor = hist.selected_opinion_value or @local.mouse_opinion_value
-    left = ((anchor + 1)/2 - hist.region_selection_width/2) * @props.width
-    base_width = hist.region_selection_width * @props.width
+    left = ((anchor + 1)/2 - REGION_SELECTION_WIDTH/2) * @props.width
+    base_width = REGION_SELECTION_WIDTH * @props.width
     selection_width = Math.min( \
                         Math.min(base_width, base_width + left), \
                         @props.width - left)
     selection_left = Math.max 0, left
 
-    DIV null,
-      if hist.selected_opinions
-        DIV 
-          className: 'selection_region_resizer'
-          style: 
-            borderBottom: "3px solid #{focus_color()}"
-            height: 15
-            width: selection_width
-            position: 'absolute'
-            left: selection_left
-            top: -15
-            cursor: 'col-resize'
+    return DIV null if hist.originating_histogram && hist.originating_histogram != @props.key
 
-      DIV 
-        style:
-          height: @props.height + @local.region_selection_vertical_padding
-          position: 'absolute'
-          width: selection_width
-          backgroundColor: "rgb(246, 247, 249)"
-          cursor: 'pointer'
-          left: selection_left
-          top: -2
+    DIV 
+      style:
+        height: @props.height + REGION_SELECTION_VERTICAL_PADDING
+        position: 'absolute'
+        width: selection_width
+        backgroundColor: "rgb(246, 247, 249)"
+        cursor: 'pointer'
+        left: selection_left
+        top: -2 #- REGION_SELECTION_VERTICAL_PADDING
+        borderTop: "2px solid"
+        borderTopColor: if hist.selected_opinions then focus_color() else 'transparent'
 
-        if !hist.selected_opinions
-          DIV
-            style: css.crossbrowserify
-              fontSize: 12
-              textAlign: 'center'
-              whiteSpace: 'nowrap'
-              marginTop: -9
-              userSelect: 'none'
-              pointerEvents: 'none'
+      if !hist.selected_opinions
+        DIV
+          style: css.crossbrowserify
+            fontSize: 12
+            textAlign: 'center'
+            whiteSpace: 'nowrap'
+            marginTop: -3 #-9
+            marginLeft: -4
+            userSelect: 'none'
+            pointerEvents: 'none'
 
-            TRANSLATE "engage.histogram.select_these_opinions", 'Select these opinions'
+          TRANSLATE "engage.histogram.select_these_opinions", 'highlight opinions'
 
   onClick: (ev) -> 
 
     ev.stopPropagation()
-    hist = fetch @props.key
+    hist = @get_hist_state()
 
     if @props.backgrounded
       if @props.on_click_when_backgrounded
@@ -436,28 +423,29 @@ window.Histogram = ReactiveComponent
       if is_clicking_user
         user_key = ev.target.getAttribute('data-user')
         user_opinion = _.findWhere @props.opinions, {user: user_key}
-        is_deselection = hist.selected_opinion == user_opinion.key && 
-                          !@local.last_selection_via_drag
+
+        is_deselection = (hist.selected_opinion == user_opinion.key || fetch('filtered').users?[user_key]) 
         if is_deselection
-          hist.selected_opinion = null
+          reset_selection_state(hist)
         else 
           hist.selected_opinion = user_opinion.key
           hist.selected_opinions = null
       else
-        max = hist.selected_opinion_value + hist.region_selection_width
-        min = hist.selected_opinion_value - hist.region_selection_width
+        max = hist.selected_opinion_value + REGION_SELECTION_WIDTH
+        min = hist.selected_opinion_value - REGION_SELECTION_WIDTH
         is_deselection = \
+          (hist.originating_histogram && hist.originating_histogram != @props.key) || ( \
           hist.selected_opinions && 
-           !@local.last_selection_via_drag &&
-           (!@local.touched || inRange(@local.mouse_opinion_value, min, max))
+           (!@local.touched || inRange(@local.mouse_opinion_value, min, max)))
 
         if is_deselection
-          hist.selected_opinions = null
+          reset_selection_state(hist)
           if ev.type == 'touchstart'
             @local.mouse_opinion_value = null
         else
           hist.selected_opinion = null
           hist.selected_opinions = @getOpinionsInCurrentRegion()
+          hist.originating_histogram = @props.key
 
       has_selection = hist.selected_opinion || hist.selected_opinions
       hist.selected_opinion_value = if !has_selection 
@@ -466,7 +454,6 @@ window.Histogram = ReactiveComponent
                                       @local.mouse_opinion_value 
                                     else 
                                       user_opinion.stance
-      @local.last_selection_via_drag = false
 
       save hist
       save @local
@@ -481,95 +468,69 @@ window.Histogram = ReactiveComponent
 
     translatePixelXToStance m_x - h_x, h_w
 
-  onMouseMove: (ev) -> 
-    return if fetch(namespaced_key('slider', @props.proposal)).is_moving
+  onMouseMove: (ev) ->     
 
-    if @props.enable_selection && !@props.backgrounded
-      hist = fetch @props.key
-      ev.stopPropagation()
+    return if fetch(namespaced_key('slider', @props.proposal)).is_moving  || \
+              @props.backgrounded || !@props.enable_range_selection
 
-      # handle drag resizing selection area
-      if hist.dragging
-        h_w = @getDOMNode().offsetWidth
-        mouse_x = ev.pageX
-        change_in_selection_region = 2 * (mouse_x - @local.mouse_x_of_last_resize) / h_w
-        hist.region_selection_width += change_in_selection_region
-        hist.region_selection_width = Math.min( 1, Math.max(.03, \
-                                                     hist.region_selection_width))
-        @local.mouse_x_of_last_resize = mouse_x
-        @local.last_selection_via_drag = true
-        save @local
-        save hist
-      else if $(ev.target).closest('.selection_region_resizer').length == 0
-        @local.hoving_over_avatar = ev.target.className.indexOf('avatar') != -1
-        @local.mouse_opinion_value = @getOpinionValueAtFocus(ev)
-
-        if @local.mouse_opinion_value + hist.region_selection_width >= 1
-          @local.mouse_opinion_value = 1 - hist.region_selection_width
-        else if @local.mouse_opinion_value - hist.region_selection_width <= -1
-          @local.mouse_opinion_value = -1 + hist.region_selection_width
-        
-        # dynamic selection on drag
-        if hist.selected_opinions &&
-            @local.mouse_opinion_value # this last conditional is only for touch
-                                       # interactions where there is no mechanism 
-                                       # for "leaving" the histogram
-          hist.selected_opinions = @getOpinionsInCurrentRegion()
-          hist.selected_opinion_value = @local.mouse_opinion_value 
-          save hist
-
-        save @local
-
-  onMouseLeave: (ev) -> 
-    return if fetch(namespaced_key('slider', @props.proposal)).is_moving
-    @local.mouse_opinion_value = null
-    save @local
-
-    hist = fetch @props.key
-    if hist.dragging
-      hist.dragging = false
-      save hist
+    hist = @get_hist_state()    
+    return if hist.originating_histogram && hist.originating_histogram != @props.key
 
 
-  onMouseUp: (ev) -> 
-    return if fetch(namespaced_key('slider', @props.proposal)).is_moving
-    hist = fetch @props.key   
+    ev.stopPropagation()
+
+    @local.hoving_over_avatar = ev.target.className.indexOf('avatar') != -1
+    @local.mouse_opinion_value = @getOpinionValueAtFocus(ev)
+
+    if @local.mouse_opinion_value + REGION_SELECTION_WIDTH >= 1
+      @local.mouse_opinion_value = 1 - REGION_SELECTION_WIDTH
+    else if @local.mouse_opinion_value - REGION_SELECTION_WIDTH <= -1
+      @local.mouse_opinion_value = -1 + REGION_SELECTION_WIDTH
     
-    if hist.dragging
-      hist.dragging = false
+    # dynamic selection on drag
+    if hist.selected_opinions &&
+        @local.mouse_opinion_value # this last conditional is only for touch
+                                   # interactions where there is no mechanism 
+                                   # for "leaving" the histogram
+      hist.selected_opinions = @getOpinionsInCurrentRegion()
+      hist.selected_opinion_value = @local.mouse_opinion_value 
       save hist
+
+    save @local
 
   onMouseDown: (ev) -> 
     return if fetch(namespaced_key('slider', @props.proposal)).is_moving
     ev.stopPropagation()
-
-    hist = fetch @props.key
-    if $(ev.target).closest('.selection_region_resizer').length > 0 && 
-        hist.selected_opinions && 
-        !@local.touched
-      hist.dragging = true
-      @local.mouse_x_of_last_resize = ev.pageX
-      save hist
-
     return false 
       # The return false prevents text selections
       # of other parts of the page when dragging
       # the selection region around.
 
+
+  onMouseLeave: (ev) -> 
+    hist = @get_hist_state() 
+
+    return if fetch(namespaced_key('slider', @props.proposal)).is_moving || \
+              (hist.originating_histogram && hist.originating_histogram != @props.key)
+    @local.mouse_opinion_value = null
+    save @local
+
+
   getOpinionsInCurrentRegion : -> 
-    # return the opinions whose stance is within +/- region_selection_width 
+    # return the opinions whose stance is within +/- REGION_SELECTION_WIDTH 
     # of the moused over area of the histogram
-    hist = fetch @props.key
+
+    hist = @get_hist_state()
     all_opinions = @props.opinions || []  
-    min = @local.mouse_opinion_value - hist.region_selection_width
-    max = @local.mouse_opinion_value + hist.region_selection_width
+    min = @local.mouse_opinion_value - REGION_SELECTION_WIDTH
+    max = @local.mouse_opinion_value + REGION_SELECTION_WIDTH
     selected_opinions = (o.key for o in all_opinions when inRange(o.stance, min, max))
     selected_opinions
 
 
   histocache_key: -> 
     filter_out = fetch 'filtered'
-    opinions = (o for o in @props.opinions when !(filter_out.users?[o.user]))
+    opinions = (o for o in @props.opinions when filter_out.enable_comparison || !(filter_out.users?[o.user]))
 
     key = JSON.stringify _.map(opinions, (o) => 
             Math.round(fetch(o.key).stance * 100) / 100 )
@@ -607,7 +568,7 @@ window.Histogram = ReactiveComponent
       noop = 1
     else if !@local.dirty && histocache_key != @local.histocache?.hash && @current_request != histocache_key
 
-      filtered_opinions = (o for o in @props.opinions when !(filter_out.users?[o.user]))
+      filtered_opinions = (o for o in @props.opinions when filter_out.enable_comparison || !(filter_out.users?[o.user]))
 
       opinions = for opinion, i in filtered_opinions
         {stance: opinion.stance, user: opinion.user}
@@ -713,7 +674,8 @@ HistoAvatars = ReactiveComponent
       for opinion, idx in @props.opinions
         user = opinion.user
 
-        if filter_out.users?[user]
+        backgrounded = filter_out.users?[user]
+        if backgrounded && !filter_out.enable_comparison
           continue
 
         o = fetch(opinion) # subscribe to changes so physics sim will get rerun...
@@ -722,7 +684,7 @@ HistoAvatars = ReactiveComponent
         # creation = new Date(o.created_at).getTime()
         # opacity = .05 + .95 * (creation - sub_creation) / (Date.now() - sub_creation)
 
-        if @props.backgrounded
+        if backgrounded || @props.backgrounded
           avatar_style = if fetch('/current_user').user == user 
                            _.extend({}, regular_avatar_style, {opacity: .25}) 
                          else 
@@ -761,8 +723,8 @@ HistoAvatars = ReactiveComponent
 
         avatar user,
           ref: "avatar-#{idx}"
-          focusable: @props.navigating_inside && !@props.backgrounded 
-          hide_tooltip: @props.backgrounded
+          focusable: @props.navigating_inside && !@props.backgrounded && !backgrounded
+          hide_tooltip: @props.backgrounded || backgrounded
           alt: "<user>: #{alt}"
           style: _.extend {}, avatar_style, 
             left: pos?[0]
@@ -974,7 +936,7 @@ positionAvatars = (opts) ->
 
 calculateAvatarRadius = (width, height, opinions) -> 
   filter_out = fetch 'filtered'
-  if filter_out.users 
+  if filter_out.users && !filter_out.enable_comparison
     opinions = (o for o in opinions when !(filter_out.users?[o.user]))
 
   opinions.sort (a,b) -> a.stance - b.stance

--- a/@client/histogram.coffee
+++ b/@client/histogram.coffee
@@ -189,6 +189,7 @@ window.Histogram = ReactiveComponent
 
     @props.enable_individual_selection &&= opinions.length > 0
     @props.enable_range_selection &&= opinions.length > 1
+    @props.enable_range_selection &&= (!filter_out.current_filter || filter_out.current_filter.label != 'just you')
 
     # whether to show the shaded opinion selection region in the histogram
     draw_selection_area = @props.enable_range_selection &&

--- a/@client/histogram.coffee
+++ b/@client/histogram.coffee
@@ -871,8 +871,8 @@ positionAvatars = (opts) ->
   # Initialize positions of each node
   targets = {}
   opinions = opts.o.slice()
-  width = opts.w || 400
-  height = opts.h || 70
+  width = opts.w or 400
+  height = opts.h or 70
   r = calculateAvatarRadius width, height, opinions
 
   nodes = opinions.map (o, i) ->

--- a/@client/histogram.coffee
+++ b/@client/histogram.coffee
@@ -708,8 +708,10 @@ HistoAvatars = ReactiveComponent
         #     # opacity: opacity
 
         stance = opinion.stance 
-        if Math.abs(stance) > .01
+        if stance > .01
           alt = "#{(stance * 100).toFixed(0)}%"
+        else if stance < -.01
+          alt = "– #{(stance * -100).toFixed(0)}%"
         else 
           alt = translator "engage.histogram.user_is_neutral", "is neutral"
 

--- a/@client/homepage.coffee
+++ b/@client/homepage.coffee
@@ -485,7 +485,7 @@ window.ManualProposalResort = ReactiveComponent
               if e.which == 13 || e.which == 32 # ENTER or SPACE
                 invalidate_proposal_sorts()
                 e.preventDefault()
-        "<button>Re-sort this list</button>  when you're ready. It is out of order."
+        "<button>Re-sort this list</button> if you want. It is out of order."
 
 
 window.Cluster = ReactiveComponent
@@ -512,7 +512,6 @@ window.Cluster = ReactiveComponent
 
     cluster_key = "list/#{cluster.name}"
 
-    console.log 'render Cluster'
     ARTICLE
       key: cluster.name
       id: if cluster.name && cluster.name then cluster.name.toLowerCase()
@@ -728,7 +727,7 @@ ClusterHeading = ReactiveComponent
                 position: 'absolute'
                 top: 0
                 right: 0
-                textAlign: 'center'
+                textAlign: 'right'
                 fontWeight: heading_style.fontWeight
                 color: heading_style.color
                 fontSize: heading_style.fontSize
@@ -760,7 +759,7 @@ window.list_actions = (props) ->
   DIV 
     style: 
       marginTop: 12
-      marginBottom: 36
+      marginBottom: 50
 
     if add_new
 
@@ -772,7 +771,7 @@ window.list_actions = (props) ->
             color: focus_color()
             fontFamily: customization('font')
             fontStyle: 'normal'
-            fontWeight: 600
+            fontWeight: 700
           onClick: (e) => 
             show_all = fetch('show_all_proposals')
             show_all.show_all = true 
@@ -795,12 +794,20 @@ window.list_actions = (props) ->
       SortProposalsMenu()
 
 
+
     OpinionFilter
       style: 
         display: 'inline-block'
         float: 'right'
         maxWidth: column_sizes().second
         textAlign: 'right'
+      enable_comparison_wrapper_style: 
+        position: 'absolute'
+        right: 0 
+        bottom: -20
+        fontSize: 14
+        zIndex: 99
+      
 
     DIV 
       style: 

--- a/@client/homepage.coffee
+++ b/@client/homepage.coffee
@@ -751,57 +751,60 @@ ClusterHeading = ReactiveComponent
 
 
 window.list_actions = (props) -> 
-  SPAN null,
 
-    if props.can_sort || props.add_new
-      DIV 
+  add_new = props.add_new
+  if add_new 
+    permitted = permit('create proposal')
+    add_new &&= permitted > 0 || permitted == Permission.NOT_LOGGED_IN
+
+  DIV 
+    style: 
+      marginTop: 12
+      marginBottom: 36
+
+    if add_new
+
+      SPAN null, 
+        A
+          style: 
+            textDecoration: 'underline'
+            fontSize: 20
+            color: focus_color()
+            fontFamily: customization('font')
+            fontStyle: 'normal'
+            fontWeight: 600
+          onClick: (e) => 
+            show_all = fetch('show_all_proposals')
+            show_all.show_all = true 
+            save show_all
+            e.stopPropagation()
+
+            setTimeout =>
+              $("[name='add_new_#{props.cluster.name}']").ensureInView()
+            , 1
+          translator "engage.add_new_proposal_to_list", 'add new'
+
+    if props.can_sort && add_new
+      SPAN 
         style: 
-          width: column_sizes().first
-          marginBottom: 12
-          display: 'inline-block'
-          verticalAlign: 'top'
+          padding: '0 24px'
+          fontSize: 20
+        '|'
 
-        if props.can_sort
-          SortProposalsMenu()
+    if props.can_sort
+      SortProposalsMenu()
 
-        if props.add_new
-          permitted = permit('create proposal')
-          if permitted > 0 || permitted == Permission.NOT_LOGGED_IN
-
-            SPAN null, 
-              if props.can_sort
-                SPAN 
-                  style: 
-                    padding: '0 12px'
-                    fontSize: 14
-                  '|'
-              A
-                style: 
-                  textDecoration: 'underline'
-                  fontSize: 14
-                  color: focus_color()
-                  fontFamily: customization('font')
-                  fontStyle: 'normal'
-                  fontWeight: 600
-                onClick: (e) => 
-                  show_all = fetch('show_all_proposals')
-                  show_all.show_all = true 
-                  save show_all
-                  e.stopPropagation()
-
-                  setTimeout =>
-                    $("[name='add_new_#{props.cluster.name}']").ensureInView()
-                  , 1
-                translator "engage.add_new_proposal_to_list", 'add new'
 
     OpinionFilter
       style: 
-        width: if props.can_sort || true then column_sizes().second
-        marginBottom: 12
-        marginLeft: column_sizes().gutter + (if props.can_sort then 0 else column_sizes().first)
-        display: if props.can_sort then 'inline-block'
-        verticalAlign: 'top'
-        textAlign: 'center' 
+        display: 'inline-block'
+        float: 'right'
+        maxWidth: column_sizes().second
+        textAlign: 'right'
+
+    DIV 
+      style: 
+        clear: 'both'
 
 
 

--- a/@client/profile_menu.coffee
+++ b/@client/profile_menu.coffee
@@ -247,13 +247,5 @@ window.ProfileMenu = ReactiveComponent
               width: 570    
 
 
-styles += """
-.menu_link {
-  position: relative;
-  bottom: 8px;
-  padding-left: 27px;
-  display: block;
-  white-space: nowrap; }
-
-.profile_menu_wrap:hover .profile_anchor{ color: inherit; }
+styles += """.profile_menu_wrap:hover .profile_anchor{ color: inherit; }
 """

--- a/@client/profile_menu.coffee
+++ b/@client/profile_menu.coffee
@@ -17,7 +17,7 @@ window.ProfileMenu = ReactiveComponent
       if is_admin then {href: '/dashboard/application', label: 'App Settings'} else null,
       if is_super then {href: '/dashboard/customizations', label: 'Customizations'} else null,      
       if is_admin then {href: '/dashboard/roles', label: 'User Roles'} else null,
-      if is_admin then {href: '/dashboard/tags', label: 'User Tags'} else null,      
+      if is_super then {href: '/dashboard/tags', label: 'User Tags'} else null,      
       if is_moderator then {href: '/dashboard/moderate', label: 'Moderate'} else null,
     ]
 

--- a/@client/profile_menu.coffee
+++ b/@client/profile_menu.coffee
@@ -1,4 +1,5 @@
 require './customizations'
+require './drop_menu'
 
 window.ProfileMenu = ReactiveComponent
   displayName: 'ProfileMenu'
@@ -19,12 +20,15 @@ window.ProfileMenu = ReactiveComponent
       if is_admin then {href: '/dashboard/roles', label: 'User Roles'} else null,
       if is_super then {href: '/dashboard/tags', label: 'User Tags'} else null,      
       if is_moderator then {href: '/dashboard/moderate', label: 'Moderate'} else null,
+      {label: 'Log out', 'data-action': 'logout'}
+
     ]
 
     menu_options = _.compact menu_options
 
     hsl = parseCssHsl(subdomain.branding.primary_color)
     light_background = hsl.l > .75
+
 
     set_focus = (idx) => 
       idx = 0 if !idx?
@@ -50,78 +54,15 @@ window.ProfileMenu = ReactiveComponent
         top: 17
 
       if current_user.logged_in
-
-        DIV null,
-
-          if subdomain.name in ['bitcoin', 'bitcoinclassic'] && \
-             current_user.logged_in && \
-             (!current_user.tags['verified']? || current_user.tags['verified'] in ['no', 'false'])
-            
-            @bitcoinVerification()
-
-          DIV
-            key: 'profile_menu'
-            ref: 'menu_wrap'
-            className: 'profile_menu_wrap'
-            style:
-              position: 'relative'
-
-            onTouchEnd: => 
-              @local.menu = !@local.menu
-              save(@local)
-
-            onMouseEnter: (e) => @local.menu = true; save(@local)
-            onMouseLeave: close_menu
-
-            onBlur: (e) => 
-              setTimeout => 
-                # if the focus isn't still on an element inside of this menu, 
-                # then we should close the menu
-                if $(document.activeElement).closest(@refs.menu_wrap.getDOMNode()).length == 0
-                  @local.menu = false; save @local
-              , 0
-
-            onKeyDown: (e) => 
-              if e.which == 13 || e.which == 32 || e.which == 27 # ENTER or ESC
-                close_menu()
-                e.preventDefault()
-              else if e.which == 38 || e.which == 40 # UP / DOWN ARROW
-                @local.focus = -1 if !@local.focus?
-                if e.which == 38
-                  @local.focus--
-                  if @local.focus < 0 
-                    @local.focus = menu_options.length 
-                else
-                  @local.focus++
-                  if @local.focus > menu_options.length 
-                    @local.focus = 0 
-                set_focus(@local.focus)
-                e.preventDefault() # prevent window from scrolling too
-
-            BUTTON 
-              tabIndex: 0
-              'aria-haspopup': "true"
-              'aria-owns': "profile_menu_popup"
-
-              style: 
-                color: if !light_background then 'white'
-                position: 'relative'
-                zIndex: 9999999999
-                backgroundColor: if !@local.menu then 'rgba(255,255,255, .1)' else 'transparent'
-                boxShadow: if !@local.menu then '0px 1px 1px rgba(0,0,0,.1)'
-                borderRadius: 8
-                padding: '3px 4px'
-                border: 'none'
-
-              onKeyDown: (e) => 
-                if e.which == 13 || e.which == 32
-                  @local.menu = true
-                  save(@local)
-                  if !@local.focus? 
-                    set_focus(0)
-                  e.preventDefault()
-                  e.stopPropagation()
-
+        DropMenu
+          options: menu_options
+          
+          selection_made_callback: (option) ->
+            if option.label == 'Log out'
+              logout()
+          
+          render_anchor: (menu_showing) -> 
+            [
               Avatar 
                 key: current_user.user
                 hide_tooltip: true
@@ -134,97 +75,47 @@ window.ProfileMenu = ReactiveComponent
               I 
                 className: 'fa fa-caret-down'
                 style: 
-                  visibility: if @local.menu then 'hidden'
+                  visibility: if menu_showing then 'hidden'
+            ]            
+          render_option: (option) -> 
+            if option.label == 'Log out'
+              translator "auth.log_out", "Log out"
+            else 
+              translator "user_menu.option.#{option.label}", option.label
+          
+          anchor_style: 
+            color: if !light_background then 'white'
+            zIndex: 9999999999
+            backgroundColor: 'rgba(255,255,255, .1)'
+            boxShadow: '0px 1px 1px rgba(0,0,0,.1)'
+            borderRadius: 8
+            padding: '3px 4px'
+          
+          anchor_when_open_style: 
+            backgroundColor: 'transparent'
+            boxShadow: 'none'
+          
+          menu_style: 
+            left: 'auto'
+            right: -9999
+            margin: '-42px 0 0 -8px'
+            padding: "56px 14px 8px 8px"
+            backgroundColor: '#eee'
+            textAlign: 'right'
+          
+          menu_when_open_style: 
+            right: 0
+          
+          option_style: 
+            color: focus_color()
+            position: 'relative'
+            bottom: 8
+            paddingLeft: 27
+            display: 'block'
+            whiteSpace: 'nowrap'  
 
-            UL 
-              id: 'profile_menu_popup'
-              role: "menu"
-              'aria-hidden': !@local.menu
-              hidden: !@local.menu
-              style: 
-                listStyle: 'none'
-                position: 'absolute'
-                left: 'auto'
-                right: if !@local.menu then -9999 else 0
-                margin: '-42px 0 0 -8px'
-                padding: "56px 14px 8px 8px"
-                backgroundColor: '#eee'
-                textAlign: 'right'
-                zIndex: 999999
-
-
-              for option, idx in menu_options
-                LI 
-                  key: option.label
-                  role: "presentation"
-                  A
-                    ref: "menuitem-#{idx}"
-                    role: "menuitem"
-                    tabIndex: if @local.focus == idx then 0 else -1
-                    className: 'menu_link'
-                    href: option.href
-                    key: option.href
-                    style: 
-                      color: if @local.focus == idx then 'black' else focus_color()
-                      outline: 'none'
-
-                    onKeyDown: (e) => 
-                      if e.which == 13 || e.which == 32 # ENTER or SPACE
-                        e.currentTarget.click()
-                        e.preventDefault()
-                    onFocus: do(idx) => (e) => 
-                      if @local.focus != idx 
-                        set_focus idx
-                      e.stopPropagation()
-                    onMouseEnter: do(idx) => => 
-                      if @local.focus != idx                         
-                        set_focus idx
-
-                    onBlur: (e) => 
-                      @local.focus = null 
-                      save @local  
-
-                    onMouseExit: (e) => 
-                      @local.focus = null 
-                      save @local
-                      e.stopPropagation()
-
-                    translator "user_menu.option.#{option.label}", option.label
-
-              LI 
-                role: "presentation"
-                key: 'logout'
-                A 
-                  ref: "menuitem-#{menu_options.length}"
-                  role: "menuitem"
-                  tabIndex: -1
-                  'data-action': 'logout'
-                  className: 'menu_link'
-                  style: 
-                    color: if @local.focus == idx then 'black' else focus_color()
-                    outline: 'none'
-                    
-                  onClick: logout
-                  onTouchEnd: logout
-                  onKeyDown: (e) => 
-                    if e.which == 13 || e.which == 32 # ENTER or SPACE
-                      logout() 
-                      e.preventDefault()
-                  onFocus: (e) => 
-                    if @local.focus != menu_options.length 
-                      set_focus menu_options.length
-                    e.stopPropagation()
-                  onMouseEnter: => 
-                    if @local.focus != menu_options.length                         
-                      set_focus menu_options.length
-                  onBlur: => 
-                    @local.focus = null 
-                    save @local                      
-                  onMouseExit: => 
-                    @local.focus = null 
-                    save @local
-
-                  translator "auth.log_out", "Log out"
+          active_option_style: 
+            color: 'black'
 
 
       else

--- a/@client/proposal_embed.coffee
+++ b/@client/proposal_embed.coffee
@@ -199,7 +199,8 @@ Proposal = ReactiveComponent
             opinions: opinionsForProposal(@proposal)
             width: histo_width
             height: 80
-            enable_selection: false
+            enable_individual_selection: false
+            enable_range_selection: false
             backgrounded: false
             draw_base_labels: true 
             draw_base: true


### PR DESCRIPTION
Default set of opinion filters: Everyone and Just you. Just you gives you a focus on crafting your opinion throughout the forum, minimizing influence from others. 

Option for showing everyone grayed out that has been filtered out of the histogram/sort order. Only shows up when an option other than “everyone” is selected. 

Homepage histograms now respond to opinion highlighting of a single person so you can see what they think across a range of proposals. They also respond to range selection (unless on mobile).  

Lists of proposals no longer automatically re-sort. This had caused a jarring effect. A manual re-sort option appears at bottom of screen if the list is no longer in the right order. 

Created a generic drop down menu component that is now used for the profile menu, sort selector, and the opinion filter selector. 

Also, removed:
- range selector resizing
- keeping list items in view after dragging slider (replaced by
manual resort)