### PR TITLE
Feedback frames

### DIFF
--- a/@client/collapsed_proposal.coffee
+++ b/@client/collapsed_proposal.coffee
@@ -232,7 +232,7 @@ window.CollapsedProposal = ReactiveComponent
 
 
 
-                if customization('discussion_enabled',proposal)
+                if customization('discussion_enabled', proposal)
                     A 
                       href: proposal_url(proposal, true)
                       style: 
@@ -245,7 +245,7 @@ window.CollapsedProposal = ReactiveComponent
 
                         "{cnt, plural, one {# consideration} other {# considerations}}"
 
-                      if proposal.active 
+                      if proposal.active && permit('create point', proposal) > 0
                         [
                           SPAN 
                             style: 

--- a/@client/filter.coffee
+++ b/@client/filter.coffee
@@ -558,7 +558,7 @@ OpinionFilter = ReactiveComponent
     users = fetch '/users' # fetched here so its ready for toggle_filter func
 
     return DIV null if !users.users
-    filters_for_admin = customization('opinion_filters_admin_only') 
+    filters_only_for_hosts = customization('opinion_filters_admin_only') 
     custom_filters = customization 'opinion_filters'
     if typeof(custom_filters) == 'function'
       custom_filters = custom_filters()
@@ -566,10 +566,6 @@ OpinionFilter = ReactiveComponent
     is_admin = fetch('/current_user').is_admin
     
     filters = [{
-                label: 'everyone'
-                tooltip: null 
-                pass: (u) -> true 
-              }, {
                 label: 'just you'
                 tooltip: null 
                 pass: (u) -> 
@@ -577,7 +573,15 @@ OpinionFilter = ReactiveComponent
                   user.key == fetch('/current_user').user
               }]
 
-    if custom_filters && (!filters_for_admin || is_admin)
+    if !customization('hide_opinions') || is_admin
+      filters.unshift {
+        label: 'everyone'
+        tooltip: null 
+        pass: (u) -> true 
+      }
+
+
+    if custom_filters && ( (!customization('hide_opinions') && !filters_only_for_hosts) || is_admin)
       for filter in custom_filters
         if !filter.admin_only || is_admin
           filters.push filter
@@ -699,7 +703,7 @@ OpinionFilter = ReactiveComponent
               color: 'white'
               backgroundColor: focus_color()
 
-          if current_filter.label != 'everyone'
+          if current_filter.label != 'everyone' && (is_admin || !customization('hide_opinions'))
             DIV 
               style: @props.enable_comparison_wrapper_style or {}
 

--- a/@client/homepage.coffee
+++ b/@client/homepage.coffee
@@ -92,11 +92,11 @@ window.Homepage = ReactiveComponent
 
     messages = []
     if customization('frozen')
-      messages.push "The forum host has frozen this forum so no changes can be made."
+      messages.push translator "engage.frozen_message", "The forum host has frozen this forum so no changes can be made."
     if customization('anonymize_everything')
-      messages.push "The forum host has participation set to anonymous."
+      messages.push translator "engage.anonymize_message", "The forum host has participation set to anonymous in this forum, so you won't be able to see the identity of others at this time."
     if customization('hide_opinions')
-      messages.push "The forum host has hidden the opinions of other participants."
+      messages.push translator "engage.hide_opinions_message", "The forum host has hidden the opinions of other participants, so you won't be able to see their specific opinions at this time."
 
     DIV 
       key: "homepage_#{subdomain.name}"      

--- a/@client/homepage.coffee
+++ b/@client/homepage.coffee
@@ -90,6 +90,14 @@ window.Homepage = ReactiveComponent
       doc.title = title
       save doc
 
+    messages = []
+    if customization('frozen')
+      messages.push "The forum host has frozen this forum so no changes can be made."
+    if customization('anonymize_everything')
+      messages.push "The forum host has participation set to anonymous."
+    if customization('hide_opinions')
+      messages.push "The forum host has hidden the opinions of other participants."
+
     DIV 
       key: "homepage_#{subdomain.name}"      
 
@@ -103,6 +111,14 @@ window.Homepage = ReactiveComponent
 
         if customization('auth_callout')
           AuthCallout()
+
+        for message in messages
+          DIV 
+            style: 
+              marginBottom: 24 
+              fontStyle: 'italic'
+            message
+
 
         if !fetch('/proposals').proposals
           ProposalsLoading()   

--- a/@client/permissions.coffee
+++ b/@client/permissions.coffee
@@ -34,7 +34,7 @@ Permission =
   INSUFFICIENT_INFORMATION : -5 # this user hasn't divulged enough 
                                 # information to take this action
   INSUFFICIENT_PRIVILEGES: -4 # we know this user can't do this
-
+  FORUM_FROZEN: -6
 
 
 #######################
@@ -47,6 +47,9 @@ Permission =
 # permission check.
 permit = (action) ->
   current_user = fetch '/current_user'
+
+  if customization('frozen')
+    return Permission.DISABLED
 
   switch action
     when 'create proposal'

--- a/@client/permissions.coffee
+++ b/@client/permissions.coffee
@@ -34,7 +34,6 @@ Permission =
   INSUFFICIENT_INFORMATION : -5 # this user hasn't divulged enough 
                                 # information to take this action
   INSUFFICIENT_PRIVILEGES: -4 # we know this user can't do this
-  FORUM_FROZEN: -6
 
 
 #######################

--- a/@client/profile_menu.coffee
+++ b/@client/profile_menu.coffee
@@ -15,7 +15,7 @@ window.ProfileMenu = ReactiveComponent
       {href: '/edit_profile', label: 'Edit Profile'},
       {href: '/dashboard/email_notifications', label: 'Email Settings'},
       if is_admin then {href: '/dashboard/data_import_export', label: 'Import / Export Data'} else null,
-      if is_admin then {href: '/dashboard/application', label: 'App Settings'} else null,
+      if is_admin then {href: '/dashboard/application', label: 'Forum Settings'} else null,
       if is_super then {href: '/dashboard/customizations', label: 'Customizations'} else null,      
       if is_admin then {href: '/dashboard/roles', label: 'Permissions & Roles'} else null,
       if is_super then {href: '/dashboard/tags', label: 'User Tags'} else null,      

--- a/@client/proposal.coffee
+++ b/@client/proposal.coffee
@@ -988,44 +988,45 @@ DecisionBoard = ReactiveComponent
           else 
             translator 'engage.save_opinion_button', 'Save your opinion'
 
-        if !your_opinion.published
+        if permit('update opinion', @proposal, your_opinion) > -1
+          if !your_opinion.published
 
-          DIV 
-            className: 'below_save'
-            style: 
-              display: 'none'
-                      
-            BUTTON 
-              className:'cancel_opinion_button primary_cancel_button'
-              onClick: => updateProposalMode('results', 'cancel_button')
-              onKeyDown: (e) => 
-                if e.which == 13 || e.which == 32 # ENTER or SPACE
-                  updateProposalMode('results', 'cancel_button')
-                  e.preventDefault()
-
-              translator 'engage.see_results_first_button', 'or just skip to the results'
-
-        else 
-
-          DIV 
-            className: 'below_save'
-            style: 
-              display: 'none'
-                      
-            BUTTON 
+            DIV 
+              className: 'below_save'
               style: 
-                textDecoration: 'underline'
-              className:'cancel_opinion_button primary_cancel_button'
-              onClick: => 
-                your_opinion.published = false 
-                save your_opinion
-              onKeyDown: (e) => 
-                if e.which == 13 || e.which == 32 # ENTER or SPACE
+                display: 'none'
+                        
+              BUTTON 
+                className:'cancel_opinion_button primary_cancel_button'
+                onClick: => updateProposalMode('results', 'cancel_button')
+                onKeyDown: (e) => 
+                  if e.which == 13 || e.which == 32 # ENTER or SPACE
+                    updateProposalMode('results', 'cancel_button')
+                    e.preventDefault()
+
+                translator 'engage.see_results_first_button', 'or just skip to the results'
+
+          else
+
+            DIV 
+              className: 'below_save'
+              style: 
+                display: 'none'
+                        
+              BUTTON 
+                style: 
+                  textDecoration: 'underline'
+                className:'cancel_opinion_button primary_cancel_button'
+                onClick: => 
                   your_opinion.published = false 
                   save your_opinion
-                  e.preventDefault()
+                onKeyDown: (e) => 
+                  if e.which == 13 || e.which == 32 # ENTER or SPACE
+                    your_opinion.published = false 
+                    save your_opinion
+                    e.preventDefault()
 
-              translator "engage.remove_my_opinion", 'Remove my opinion'
+                translator "engage.remove_my_opinion", 'Remove my opinion'
 
 
 
@@ -1139,14 +1140,17 @@ window.saveOpinion = (proposal) ->
     your_opinion.published = true
     save your_opinion
     updateProposalMode('results', 'save_button')
+  else if can_opine == Permission.DISABLED
+    updateProposalMode('results', 'save_button') 
   else
+    # trigger authentication
     if can_opine == Permission.UNVERIFIED_EMAIL
       auth_form = 'verify email'
       current_user.trying_to = 'send_verification_token'
       save current_user
     else if can_opine == Permission.INSUFFICIENT_INFORMATION
       auth_form = 'user questions'
-    else
+    else 
       auth_form = 'create account'
 
     reset_key 'auth',
@@ -1473,10 +1477,10 @@ PointsList = ReactiveComponent
                 enable_dragging: @props.points_draggable
 
 
-      if @props.drop_target
+      if @props.drop_target && permit('publish opinion', @proposal) > 0
         @drawDropTarget()
 
-      if @props.points_editable
+      if @props.points_editable && permit('create point', @proposal) > 0 
         @drawAddNewPoint()
       ] 
 

--- a/@client/shared.coffee
+++ b/@client/shared.coffee
@@ -864,7 +864,7 @@ a.skip:hover {
   font-size: 16px;
   color: black;
   min-height: 100%; 
-  font-weight: 300;
+  font-weight: 400;
 }
 
 

--- a/@email/email_templates/digest_mailer/digest.haml
+++ b/@email/email_templates/digest_mailer/digest.haml
@@ -4,6 +4,21 @@
   *** #{translator({id: "email.digest.text_header"}, "Recent activity")} ***
   ***********************
 
+- if @anonymize_everything || @hide_opinions
+
+  = section('Forum settings')
+
+  - if @anonymize_everything
+    %div
+      = translator "email.anonymize_message", "The forum host has participation set to anonymous, so you won't be able to see the identity of others at this time."
+
+  - if @hide_opinions
+    %div
+      = translator "email.hide_opinions", "The forum host has hidden the opinions of other participants, so you won't be able to see their specific opinions at this time."
+
+  = end_section()
+
+
 - if @new_stuff && @new_stuff.key?(:your_proposals) && @new_stuff[:your_proposals].length > 0 
   
   = section('Your proposals')

--- a/@email/email_templates/helpers/mailer_helper.rb
+++ b/@email/email_templates/helpers/mailer_helper.rb
@@ -84,7 +84,8 @@ module MailerHelper
     opinions = proposal.opinions.published
     has_relationship = proposal_info.key?(:relationship) && proposal_info[:relationship]
 
-    author_text = translator({id: 'email.digest.proposal_author', author: proposal.user.name}, "by {author}")
+
+    author_text = translator({id: 'email.digest.proposal_author', author: @anonymize_everything ? 'Anonymous' : proposal.user.name}, "by {author}")
     points_count = translator({id: 'email.digest.points_count', cnt: points.count}, "{ cnt, plural,
                     =0 {no points}
                     one {# point}
@@ -242,8 +243,15 @@ module MailerHelper
   end
 
   def people_list(users)
-    if users.length > 1
-      translator({id: "email.digest.people_list", name: users[0].name, cnt: users.length}, 
+    if @anonymize_everything
+      translator({id: "email.digest.anonymized_people_list", cnt: users.length}, 
+                "{ cnt, plural,
+                  one {One participant}
+                  other {# participants}
+                 }")        
+
+    elsif users.length > 1
+      translator({id: "email.digest.people_list", name: users[0].name, cnt: users.length - 1}, 
                 "{name} and { cnt, plural,
                   one {one other}
                   other {# others}

--- a/@email/mailers/digest_mailer.rb
+++ b/@email/mailers/digest_mailer.rb
@@ -12,6 +12,10 @@ class DigestMailer < Mailer
     @subdomain_notifications = (notifications['Subdomain'] || {})[subdomain.id]
     # @proposal_notifications = notifications['Proposal'] || {}
 
+
+    @anonymize_everything = subdomain.customization_json['anonymize_everything']
+    @hide_opinions = subdomain.customization_json['hide_opinions']
+
     @subdomain = subdomain
     @user = user
 

--- a/@email/send_digest.rb
+++ b/@email/send_digest.rb
@@ -9,7 +9,6 @@ def send_digest(subdomain, user, notifications, subscription_settings, deliver =
             (!force && !due_for_notification(user, subdomain)) || \
             !valid_triggering_event(notifications, subscription_settings) || \
             subdomain.customization_json['email_notifications_disabled'] || \
-            subdomain.customization_json['frozen'] || \
             ['galacticfederation', 'ainaalohafutures', 'denverclimateaction'].include?(subdomain.name)
 
   # Hack!! this notification system is terrible, so I'm going to add even more entropy.

--- a/@email/send_digest.rb
+++ b/@email/send_digest.rb
@@ -8,6 +8,8 @@ def send_digest(subdomain, user, notifications, subscription_settings, deliver =
   return if !send_emails || \
             (!force && !due_for_notification(user, subdomain)) || \
             !valid_triggering_event(notifications, subscription_settings) || \
+            subdomain.customization_json['email_notifications_disabled'] || \
+            subdomain.customization_json['frozen'] || \
             ['galacticfederation', 'ainaalohafutures', 'denverclimateaction'].include?(subdomain.name)
 
   # Hack!! this notification system is terrible, so I'm going to add even more entropy.


### PR DESCRIPTION
Implementing functionality needed to support the Feedback Frames methodology. Specifically added forum-level toggleable options for: 

(1) anonymizing everything (including in email notifications)

(2) hiding the opinions of others (including point inclusions)

(3) freezing a forum so that nothing can be added, changed, or removed

For good measure, I also added an option for disabling email notifications for the forum entirely.