### PR TITLE
Legal document update, including DPA

### DIFF
--- a/@client/document.coffee
+++ b/@client/document.coffee
@@ -151,54 +151,49 @@ window.DocumentationGroup = ReactiveComponent
 
 
 
-      ##########################################
-      # Temporarily removed until new legal docs are ready
-      if false 
-        if group_config.groups.length == 1 # flat list
+      if group_config.groups.length == 1 # flat list
+        DIV 
+          className: 'doc_menu'
+
+          UL 
+            style: {}
+
+            for item in group_config.groups[0].docs
+              fetch "/docs/#{item.path}" # just to preload
+              LI 
+                className: if item.path == doc then 'active'
+
+                A 
+                  href: "/docs/#{group}/#{item.path}"
+                  item.name
+
+      else 
+        DIV 
+          className: 'doc_groups_container'
+
+          H1
+            className: 'doc_center'
+            group_config.name
+
           DIV 
-            className: 'doc_menu'
+            className: 'doc_groups'
 
-            UL 
-              style: {}
+            for ggroup in group_config.groups
+              DIV 
+                className: 'doc_group'
 
-              for item in group_config.groups[0].docs
-                fetch "/docs/#{item.path}" # just to preload
-                LI 
-                  className: if item.path == doc then 'active'
+                H2 null,
+                  ggroup.label
 
-                  A 
-                    href: "/docs/#{group}/#{item.path}"
-                    item.name
+                UL null,
+                  for item in ggroup.docs
+                    fetch "/docs/#{item.path}" # just to preload
+                    LI 
+                      className: if item.path == doc then 'active'
 
-        else 
-          DIV 
-            className: 'doc_groups_container'
-
-            H1
-              className: 'doc_center'
-              group_config.name
-
-            DIV 
-              className: 'doc_groups'
-
-              for ggroup in group_config.groups
-                DIV 
-                  className: 'doc_group'
-
-                  H2 null,
-                    ggroup.label
-
-                  UL null,
-                    for item in ggroup.docs
-                      fetch "/docs/#{item.path}" # just to preload
-                      LI 
-                        className: if item.path == doc then 'active'
-
-                        A 
-                          href: "/docs/#{group}/#{item.path}"
-                          item.name
-        ######################
-
+                      A 
+                        href: "/docs/#{group}/#{item.path}"
+                        item.name
 
 
 

--- a/@server/controllers/subdomain_controller.rb
+++ b/@server/controllers/subdomain_controller.rb
@@ -54,7 +54,7 @@ class SubdomainController < ApplicationController
       errors.push "You must specify a forum name"
     end 
 
-    existing = Subdomain.find_by_name(subdomain) || ['aeb', 'cs', 'de', 'en', 'es', 'fr', 'heb', 'hu', 'mi', 'nl', 'pt', 'sk'].index(subdomain) || subdomain.start_with?('oauth-')
+    existing = Subdomain.find_by_name(subdomain) || ['status', 'aeb', 'cs', 'de', 'en', 'es', 'fr', 'heb', 'hu', 'mi', 'nl', 'pt', 'sk'].index(subdomain) || subdomain.start_with?('oauth-')
     if existing
       errors.push "That forum already exists. Please choose a different name."
     end 

--- a/public/docs/data_processing_addendum.md
+++ b/public/docs/data_processing_addendum.md
@@ -1,0 +1,387 @@
+Consider.it Data Processing Addendum
+====================================
+
+Updated: January 2023
+
+This Data Processing Addendum ("**DPA**”) is part of the [Forum Hosting Terms](/docs/legal/standard_hosting_terms), [Terms of Service](/docs/legal/terms_of_service) and [Privacy Policy](/docs/legal/privacy_policy), both as updated from time to time, or other written or electronic agreement between Consider.it LLC ("Consider.it", "Us", "We") and Customer for the purchase and/or use of online services from Consider.it LLC (identified either as “Services” or otherwise in the applicable agreement, and hereinafter defined as "**Services**”) to reflect the parties’ agreement with regard to the Processing of Personal Data (the "**Agreement**”).
+
+Customer enters into this DPA on behalf of itself and, to the extent required under applicable Data Protection Laws, in the name and on behalf of Customer’s Authorized Affiliates, if and to the extent Consider.it processes Personal Data for which such Authorized Affiliates qualify as the Controller. For the purposes of this DPA only, and except where indicated otherwise, the term “Customer” shall include Customer and Authorized Affiliates. All capitalized terms not defined herein shall have the meaning set forth in the Agreement.
+
+In the course of providing the Services to Customer pursuant to the Agreement, Consider.it may Process Personal Data on behalf of Customer and the Parties agree to comply with the following provisions with respect to any Personal Data, each acting reasonably and in good faith.
+
+
+DATA PROCESSING TERMS
+---------------------
+
+### 1. DEFINITIONS
+
+"**Affiliate**” means (a) any entity on whose behalf Customer obtained the Consider.it Services, and/or (b) any entity that directly or indirectly controls, is controlled by, or is under common control with the subject entity. “Control,” for purposes of this definition, means direct or indirect ownership or control of more than 50% of the voting interests of the subject entity.
+
+"**Authorized Affiliate**” means any of Customer’s Affiliate(s) which (a) is subject to the Data Protection Laws of the European Union, the European Economic Area and/or their member states, Switzerland and/or the United Kingdom, and (b) is permitted to use the Services pursuant to the Agreement between Customer and Consider.it, but has not signed its own Agreement with Consider.it and is not a “Customer” as defined under the Agreement.
+
+"**Controller**” means the entity which determines the purposes and means of the Processing of Personal Data.
+
+"**Data Protection Laws**” means all laws and regulations, including laws and regulations of the European Union, the European Economic Area and their member states, Switzerland and the United Kingdom, applicable to the Processing of Personal Data under the Agreement.
+
+"**Personal Data**” means any Customer Data that relates to an identified or identifiable natural person, to the extent that such information is protected as personal data under applicable Data Protection Laws. In the Consider.it [Privacy Policy](/docs/legal/privacy_policy), Personal Data is referred to as “your data”, “your info” or similar terms. 
+
+"**Data Subject**” means the identified or identifiable person to whom Personal Data relates.
+
+"**GDPR**” means the Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data, and repealing Directive 95/46/EC (General Data Protection Regulation).
+
+"**Processing**” (including its various forms) means any operation or set of operations which is performed upon Personal Data, whether or not by automatic means, such as collection, recording, organization, structuring, storage, adaptation or alteration, retrieval, consultation, use, disclosure by transmission, dissemination or otherwise making available, alignment or combination, restriction, erasure or destruction.
+
+"**Processor**” means the entity which Processes Personal Data on behalf of the Controller.
+
+"**Security Practices Documentation**” means Consider.it’s [security overview](/docs/legal/security), as updated from time to time and Consider.it’s [Privacy Policy](/docs/legal/privacy_policy), as updated from time to time, accessible on the Consider.it website at https://consider.it/docs/legal/security and https://consider.it/docs/legal/privacy_policy, respectively.
+
+"**Consider.it**” means the Consider.it entity which is a party to this DPA, being Consider.it LLC, a Limited Liability Company of the State of Oregon in the United States.
+
+"**Standard Contractual Clauses**” means Standard Contractual Clauses for the transfer of Personal Data to third countries set out in Commission Implementing Decision (EU) 2021/914 of 4 June 2021 on standard contractual clauses for the transfer of personal data to third countries pursuant to Regulation (EU) 2016/679 of the European Parliament and of the Council, as currently set out at http://data.europa.eu/eli/dec_impl/2021/914/oj.
+
+"**Sub-processor**” means any Processor engaged by Consider.it.
+
+"**Supervisory Authority**” means an independent public authority which is established by an EEA State pursuant to the GDPR, the UK’s Information Commissioner’s Office and/or the Swiss Federal Data Protection and Information Commissioner.
+
+### 2. PROCESSING OF PERSONAL DATA
+
+2.1 **Roles of the Parties**. The parties acknowledge and agree that with regard to the Processing of Personal Data, Customer is always a Controller of Personal Data and Consider.it is a Processor.
+
+2.2 **Customer’s Processing of Personal Data**. Customer shall, in its use of the Services:
+
+2.2.1 Process Personal Data in accordance with the requirements of Data Protection Laws. For the avoidance of doubt, Customer’s instructions for the Processing of Personal Data shall comply with Data Protection Laws;
+
+2.2.2 have sole responsibility for the accuracy, quality, and legality of Personal Data and the means by which Customer acquired Personal Data;
+
+2.2.3 have provided adequate notices to, and obtained valid consents from, any data subjects, relating to the Processing (including the sharing) of Personal Data by Customer and as applicable, to the transfer of such Personal Data outside of the EEA/Switzerland/UK; and
+
+2.2.4 shall not, by act or omission, cause Consider.it to violate any Data Protection Laws, notices provided to, or consents obtained from, data subjects as result of Processing the Personal Data.
+
+
+2.3 **Consider.it’s Processing of Personal Data**
+
+2.3.1 Consider.it shall treat Personal Data as confidential information and shall only Process Personal Data on behalf of and in accordance with Customer’s documented instructions for the following purposes: (i) Processing in accordance with the Agreement; (ii) Processing initiated by Customers and/or Invited Users in their use of the Services; and (iii) Processing to comply with other documented reasonable instructions provided by Customer (e.g., via email) where such instructions are consistent with the terms of the Agreement.
+
+2.3.2 **Details of the Processing**. The subject-matter of Processing of Personal Data by Consider.it is the performance of the Services pursuant to the Agreement. The duration of the Processing, the nature and purpose of the Processing, the types of Personal Data and categories of Data Subjects Processed under this DPA are further specified in Schedule 2 (Description of Processing / Transfer) to this DPA.
+
+
+
+### 3. RIGHTS OF DATA SUBJECTS
+
+3.1 **Data Subject Requests.** Consider.it shall, to the extent legally permitted, promptly notify Customer if Consider.it receives a request from a Data Subject to exercise the Data Subject’s right of access, right to rectification, restriction of Processing, erasure (“right to be forgotten”), data portability, object to the Processing, or its right not to be subject to an automated individual decision making (“Data Subject Request”). Taking into account the nature of the Processing, Consider.it shall assist Customer by appropriate technical and organizational measures, insofar as this is possible, for the fulfilment of Customer’s obligation to respond to a Data Subject Request under Data Protection Laws. In addition, to the extent Customer, in its use of the Services, does not have the ability to address a Data Subject Request, Consider.it shall upon Customer’s request provide commercially reasonable efforts to assist Customer in responding to such Data Subject Request, to the extent Consider.it is legally permitted to do so and the response to such Data Subject Request is required under Data Protection Laws. To the extent legally permitted, Customer shall be responsible for any costs arising from Consider.it’s provision of such assistance.
+
+### 4. SUB-PROCESSORS
+
+4.1 **Appointment of Sub-processors.** Customer acknowledges and agrees that (a) Consider.it’s Affiliates may be retained as Sub-processors; and (b) Consider.it and Consider.it’s Affiliates respectively may engage third-party Sub-processors in connection with the provision of the Services. Consider.it or a Consider.it Affiliate has entered into a written agreement with each Sub-processor containing data protection obligations not less protective than those in this DPA with respect to the protection of Customer Data to the extent applicable to the nature of the Services provided by such Sub-processor.
+
+
+4.2 **List of Current Sub-processors and Notification of New Sub-processors.** Consider.it shall make available to Customer the current list of Sub-processors for Consider.it Services. Such Sub-processor lists shall include the identities of those Sub-processors (“Sub-processor Documentation”). Customer may find on Consider.it’s webpage at https://consider.it/docs/legal/subprocessors the Sub-processor Documentation. Consider.it, through notification to the Customer shall provide notification of a new Sub-processor(s) before authorizing any new Subprocessor(s) to Process Personal Data in connection with the provision of the applicable Services.
+
+4.3 **Objection Right for New Sub-processors.** Customer may object to Consider.it’s use of a new Sub-processor by notifying Consider.it in writing within ten (10) business days after receipt of Consider.it’s notice in accordance with the mechanism set out in Section 6.2. In the event Customer objects to a new Sub-processor, Consider.it will use reasonable efforts to make available to Customer a change in the Services or recommend a commercially reasonable change to Customer’s configuration or use of the Services to avoid Processing of Personal Data by the objected-to new Sub-processor without unreasonably burdening the Customer. If Consider.it is unable to make available such change within a reasonable period of time, which shall not exceed thirty (30) days, Customer may terminate the applicable Agreement with respect only to those Services which cannot be provided by Consider.it without the use of the objected-to new Sub-processor by providing written notice to Consider.it. Consider.it will refund Customer any prepaid fees covering the remainder of the term of such Agreement following the effective date of termination with respect to such terminated Services, without imposing a penalty for such termination on Customer.
+
+4.4 **Liability.** Consider.it shall be liable for the acts and omissions of its Sub-processors to the same extent Consider.it would be liable if performing the services of each Sub-processor directly under the terms of this DPA, except as otherwise set forth in the Agreement.
+
+
+### 5. SECURITY
+
+5.1 **Controls for the Protection of Personal Data.** Consider.it shall maintain appropriate technical and organizational measures for protection of the security (including protection against unauthorized or unlawful Processing and against accidental or unlawful destruction, loss or alteration or damage, unauthorized disclosure of, or access to, Personal Data), confidentiality and integrity of Personal Data, as set forth in the [Security Practices Documentation](/docs/legal/security). Consider.it will not materially decrease the overall security of the Services.
+
+5.2 **Third-Party Audits.** 
+
+5.2.1 Upon Customer’s written request at reasonable intervals, and subject to the confidentiality obligations set forth in the Agreement, Consider.it shall make available to Controller all information reasonably necessary to demonstrate compliance with its processing obligations and allow for and contribute to audits and inspections.
+
+5.2.2 Any audit conducted under this DPA shall consist of examination of the most recent reports, certificates and/or extracts prepared by an independent auditor bound by confidentiality provisions similar to those set out in the Agreement. In the event that provision of the same is not deemed sufficient in the reasonable opinion of the Controller, the Controller may conduct a more extensive audit which shall be: (i) at the Controller’s expense; (ii) limited in scope to matters specific to the Controller and agreed in advance; (iii) carried out during the Processor’s usual business hours and upon reasonable notice which shall be not less than 4 weeks unless an identifiable material issue has arisen; and (iv) conducted in a way which does not interfere with the Processor’s day-to-day business.
+
+5.2.3 This clause shall not modify or limit the rights of audit of the Controller, instead it is intended to clarify the procedures in respect of any audit undertaken pursuant thereto.
+
+5.3 **Data Protection Impact Assessment.** Upon Customer’s request, Consider.it shall provide Customer with reasonable cooperation and assistance needed to fulfil Customer’s obligation under Data Protection Laws to carry out a data protection impact assessment related to Customer’s use of the Services, to the extent Customer does not otherwise have access to the relevant information, and to the extent such information is available to Consider.it. 
+
+### 6. PERSONAL DATA INCIDENT MANAGEMENT AND NOTIFICATION
+
+Consider.it shall, notify Customer without undue delay, and in compliance with applicable laws, after becoming aware of the accidental or unlawful destruction, loss, alteration, unauthorized disclosure of, or access to Personal Data, including Personal Data, transmitted, stored or otherwise Processed by Consider.it or its Sub-processors of which Consider.it becomes aware (a **“Personal Data Incident”**). Consider.it shall make reasonable efforts to identify the cause of such Personal Data Incident and take those steps as Consider.it deems necessary and reasonable in order to remediate the cause of such a Personal Data Incident to the extent the remediation is within Consider.it’s reasonable control. The obligations herein shall not apply to incidents that are caused by Customer or Customer’s Invited Users.
+
+
+
+### 7. CONSIDER.IT PERSONNEL
+
+7.1 **Confidentiality.** Consider.it shall ensure that its personnel engaged in the Processing of Personal Data are informed of the confidential nature of the Personal Data, have received appropriate training on their responsibilities and have executed written confidentiality agreements. Consider.it shall ensure that such confidentiality obligations survive the termination of the personnel engagement.
+
+7.2 **Reliability.** Consider.it shall take commercially reasonable steps to ensure the reliability of any Consider.it personnel engaged in the Processing of Personal Data.
+
+7.3 **Limitation of Access.** Consider.it shall ensure that Consider.it’s access to Personal Data is limited to those personnel performing Services in accordance with the Agreement.
+
+7.4 **Data Protection Officer (DPO).** Consider.it has appointed Travis Kriplean as the DPO for Consider.it LLC. For questions about this DPA or any other privacy issues please send an email to [travis@consider.it](mailto:travis@consider.it).
+
+
+
+### 8. RETURN AND DELETION OF PERSONAL DATA
+Upon termination of the Services for which Consider.it is Processing Personal Data, Consider.it shall, upon Customer’s request, and subject to the limitations described in the Agreement and the Security Practices Documentation, return all Personal Data in Consider.it’s possession to Customer and/or securely destroy such Personal Data and demonstrate to the satisfaction of Customer that it has taken such measures, unless applicable law prevents it from returning or destroying all or part of Personal Data. For clarification, depending on the Service plan purchased by Customer, access to export functionality may incur additional charge(s) and/or require purchase of a Service upgrade. Until Personal Data is deleted or returned, Consider.it shall continue to comply with this DPA and its Schedules.
+
+
+### 9. AUTHORIZED AFFILIATES
+
+9.1 **Contractual Relationship.** The parties acknowledge and agree that, by entering into the DPA, the Customer enters into the DPA on behalf of itself and, as applicable, in the name and on behalf of its Authorized Affiliates, thereby establishing a separate DPA between Consider.it and each such Authorized Affiliates subject to the provisions of the Agreement and this Section 10. Each Authorized Affiliate agrees to be bound by the obligations under this DPA and, to the extent applicable, the Agreement. For the avoidance of doubt, by Customer entering into this DPA, an Authorized Affiliate is not and does not become a party to the Agreement, and is only a party to the DPA. All access to and use of the Services and Content by Authorized Affiliates must comply with the terms and conditions of the Agreement and any violation of the terms and conditions of the Agreement by an Authorized Affiliate shall be deemed a violation by Customer.
+
+9.2 **Communication.** The Customer that is the contracting party to the Agreement shall remain responsible for coordinating all communication with Consider.it under this DPA and be entitled to make and receive any communication in relation to this DPA on behalf of its Authorized Affiliate.
+
+9.3 **Rights of Authorized Affiliates.** Where an Authorized Affiliate becomes a party to the DPA with Consider.it, it shall to the extent required under applicable Data Protection Laws be entitled to exercise the rights and seek remedies under this DPA, subject to the following:
+
+9.3.1 Except where applicable Data Protection Laws require the Authorized Affiliate to exercise a right or seek any remedy under this DPA against Consider.it directly by itself, the parties agree that (i) solely the Customer that is the contracting party to the Agreement shall exercise any such right or seek any such remedy on behalf of the Authorized Affiliate, and (ii) the Customer that is the contracting party to the Agreement shall exercise any such rights under this DPA not separately for each Authorized Affiliate individually but in a combined manner for all of its Authorized Affiliates together (as set forth, for example, in Section 10.3.2, below).
+
+9.3.2 The parties agree that the Customer that is the contracting party to the Agreement shall, when carrying out an on-site audit of the procedures relevant to the protection of Personal Data, take all reasonable measures to limit any impact on Consider.it and its Sub-processors by combining, to the extent reasonably possible, several audit requests carried out on behalf of different Authorized Affiliates in one single audit.
+
+### 10. LIMITATION OF LIABILITY
+
+Each party’s and all of its Affiliates’ liability, taken together in the aggregate, arising out of or related to this DPA, and all DPAs between Authorized Affiliates and Consider.it, whether in contract, tort or under any other theory of liability, is subject to the limitations of liability set forth in the Agreement, and such limitations apply to the aggregate liability of that party and all of its Affiliates under the Agreement and all DPAs together.
+
+For the avoidance of doubt, Consider.it’s and its Affiliates’ total liability for all claims from the Customer and all of its Authorized Affiliates arising out of or related to the Agreement and each DPA shall apply in the aggregate for all claims under both the Agreement and all DPAs established under this Agreement, including by Customer and all Authorized Affiliates, and, in particular, shall not be understood to apply individually and severally to Customer and/or to any Authorized Affiliate that is a contractual party to any such DPA.
+
+Also for the avoidance of doubt, each reference to the DPA in this DPA means this DPA including its Schedules and Appendices.
+
+### 11. EUROPEAN SPECIFIC PROVISIONS
+
+11.1 **Definitions.** For the purposes of this section 11 and Schedule 1 these terms shall be defined as follows:
+  * "EU C-to-P Transfer Clauses" means Standard Contractual Clauses sections I, II, III and IV (as applicable) to the extent they reference Module Two (Controller-to-Processor).
+  * "EU P-to-P Transfer Clauses" means Standard Contractual Clauses sections I, II III and IV (as applicable) to the extent they reference Module Three (Processor-to-Processor).
+
+11.2 **GDPR.** Consider.it will Process Personal Data in accordance with the GDPR requirements directly applicable to Consider.it's provisioning of the Services.
+
+11.3 **Customer Instructions.** Consider.it shall inform Customer immediately (i) if, in its opinion, an instruction from Customer constitutes a breach of the GDPR and/or (ii) if Consider.it is unable to follow Customer's instructions for the Processing of Personal Data.
+
+11.4 **Transfer Mechanisms.** If, in the performance of the Services, Personal Data that is subject to the GDPR or any other law relating to the protection or privacy of individuals that apply in Europe is transferred out of Europe to countries which do not ensure an adequate level of data protection within the meaning of the Data Protection Laws of Europe, the EU C-to-P Transfer Clauses shall apply and can be directly enforced by the parties to the extent such transfers are subject to the Data Protection Laws of Europe, subject to the additional terms in section 1 of Schedule 1.
+
+11.5 **Impact of local laws.** As of the Effective Date, Consider.it has no reason to believe that the laws and practices in any third country of destination applicable to its Processing of the Personal Data as set forth in the Sub-processor Lists (https://consider.it/docs/legal/subprocessors), including any requirements to disclose personal data or measures authorising access by a Public Authority, prevent Consider.it from fulfilling its obligations under this DPA. If Consider.it reasonably believes that any existing or future enacted or enforceable laws and practices in the third country of destination applicable to its Processing of the Personal Data ("Local Laws") prevent it from fulfilling its obligations under this DPA, it shall promptly notify Customer. In such a case, Consider.it shall use reasonable efforts to make available to the affected Customer a change in the Services or recommend a commercially reasonable change to Customer's configuration or use of the Services to facilitate compliance with the Local Laws without unreasonably burdening Customer. If Consider.it is unable to make available such change within a reasonable period of time, either party may without penalty, terminate the applicable Order Form(s) with respect only to those Services which cannot be provided by Consider.it in accordance with the Local Laws, by providing written notice to Consider.it. Consider.it will refund Customer any prepaid fees covering the remainder of the term of such Order Form(s) following the effective date of termination with respect to such terminated Services, without imposing a penalty for such termination on Customer.
+
+**List of Schedules**
+
+Schedule 1: Transfer Mechanisms for European Data Transfers
+
+Schedule 2: Description of Processing/Transfer
+
+The parties’ authorized signatures have duly executed this Agreement:
+
+
+
+
+**Limited Customer** (as registered with Consider.it):
+
+Signature:
+
+Name: 
+
+Position: 
+
+Email: 
+
+Date: 
+
+
+**Consider.it**:
+
+Signature:
+
+Name: Travis Kriplean
+
+Position: Chief Executive Officer
+
+Email: travis@consider.it
+
+Date: 
+
+
+
+
+
+
+
+## SCHEDULE 1: TRANSFER MECHANISMS FOR EUROPEAN DATA TRANSFERS
+
+### 1. STANDARD CONTRACTUAL CLAUSES OPERATIVE PROVISIONS AND ADDITIONAL TERMS
+
+For the purposes of the EU C-to-P Transfer Clauses and the EU P-to-P Transfer Clauses, Customer is the data exporter and Consider.it LLC is the data importer and the parties agree to the following. If and to the extent a Controller Affiliate relies on the EU C-to-P Transfer Clauses or the EU P-to-P Transfer Clauses for the transfer of Personal Data, any references to ’Customer’ in this Schedule include such Controller Affiliate. Where this section 1 does not explicitly mention EU C-to-P Transfer Clauses or EU P-to-P Transfer Clauses it applies to both of them.
+
+1.1. **Reference to the Standard Contractual Clauses.** The relevant provisions contained in the Standard Contractual Clauses are incorporated by reference and are an integral part of this DPA. The information required for the purpose of the Appendix to the Standard Contractual Clauses is set out in Schedule 2.
+
+1.2. **Docking clause.** This option under clause 7 shall not apply.
+
+1.3. **Instructions.** This DPA and the Agreement are Customer’s complete and final instructions at the time of execution of the DPA for the Processing of Personal Data. Any additional or alternate instructions must be consistent with the terms of this DPA and the Agreement. For the purposes of Clause 8.1(a), the instructions by Customer to process Personal Data are set out in section 2.3 of the DPA and include onward transfers to a third party located outside Europe for the purpose of the performance of the Services.
+
+1.4. **Security of Processing.** For the purposes of clause 8.6(a), Customer is solely responsible for making an independent determination as to whether the technical and organisational measures set forth in the [Security Practices Documentation](/docs/legal/security) meet Customer’s requirements and agrees that (taking into account the state of the art, the costs of implementation, and the nature, scope, context and purposes of the processing of its Personal Data as well as the risks to individuals) the security measures and policies implemented and maintained by Consider.it provide a level of security appropriate to the risk with respect to its Personal Data. For the purposes of clause 8.6(c), personal data breaches will be handled in accordance with section 6 (Personal Data Incident Management and Notification) of the DPA.
+
+1.5. **General authorisation for use of Sub-processors.** Option 2 under clause 9 shall apply. For the purposes of clause 9(a), Consider.it has Customer’s general authorisation to engage Sub-processors in accordance with section 4 of the DPA. Consider.it shall make available to Customer the current list of Sub-processors in accordance with Section 4.2 of the DPA. Where Consider.it enters into the EU P-to-P Transfer Clauses with a Sub-processor in connection with the provision of the Services, Customer hereby grants Consider.it and Consider.it’s Affiliates authority to provide a general authorisation on Controller’s behalf for the engagement of sub-processors by Sub-processors engaged in the provision of the Services, as well as decision making and approval authority for the addition or replacement of any such sub- processors.
+
+1.6. **Notification of New Sub-processors and Objection Right for new Sub-processors.** Pursuant to clause 9(a), Customer acknowledges and expressly agrees that Consider.it may engage new Sub-processors as described in sections 4.2 and 4.3 of the DPA. Consider.it shall inform Customer of any changes to Sub-processors following the procedure provided for in section 4.2 of the DPA.
+
+1.7. **Audits of the Standard Contractual Clauses.** The parties agree that the audits described in clause 8.9 of the Standard Contractual Clauses shall be carried out in accordance with Section 5.2 (“Audit”) of the DPA.
+
+1.8. **Complaints - Redress.** For the purposes of clause 11, and subject to section 3 of the DPA, Consider.it shall inform Data Subjects on its website of a contact point authorised to handle complaints. Consider.it shall inform Customer if it receives a complaint by, or a dispute from, a Data Subject with respect to Personal Data and shall without undue delay communicate the complaint or dispute to Customer. Consider.it shall not otherwise have any obligation to handle the request (unless otherwise agreed with Customer). The option under clause 11 shall not apply.
+
+1.9. **Liability.** Consider.it’s liability under clause 12(b) shall be limited to any damage caused by its Processing where Consider.it has not complied with its obligations under the GDPR specifically directed to Processors, or where it has acted outside of or contrary to lawful instructions of Customer, as specified in Article 82 GDPR.
+
+1.10. **Certification of Deletion.** The parties agree that the certification of deletion of Personal Data that is described in clause 8.5 and 16(d) of the Standard Contractual Clauses shall be provided by Consider.it to Customer only upon Customer’s written request.
+
+1.11. **Supervision.** Clause 13 shall apply as follows:
+<ul style="list-style: none">
+<li>1.11.1 Where Customer is established in an EU Member State, the supervisory authority with responsibility for ensuring compliance by Customer with Regulation (EU) 2016/679 as regards the data transfer shall act as competent supervisory authority.</li>
+
+<li>1.11.2 Where Customer is not established in an EU Member State, but falls within the territorial scope of application of Regulation (EU) 2016/679 in accordance with its Article 3(2) and has appointed a representative pursuant to Article 27(1) of Regulation (EU) 2016/679, the supervisory authority of the Member State in which the representative within the meaning of Article 27(1) of Regulation (EU) 2016/679 is established shall act as competent supervisory authority.</li>
+
+<li>1.11.3 Where Customer is not established in an EU Member State, but falls within the territorial scope of application of Regulation (EU) 2016/679 in accordance with its Article 3(2) without however having to appoint a representative pursuant to Article 27(2) of Regulation (EU) 2016/679, the Irish Data Protection Commission shall act as competent supervisory authority.</li>
+
+<li>1.11.4 Where Customer is established in the United Kingdom, or falls within the territorial scope of application of the Data Protection Laws of the United Kingdom ("UK Data Protection Laws and Regulations") the Information Commissioner’s Office ("ICO") shall act as competent supervisory authority.</li>
+
+<li>1.11.5 Where Customer is established in Switzerland or falls within the territorial scope of application of the Data Protection Laws of Switzerland ("Swiss Data Protection Laws and Regulations,"), the Swiss Federal Data Protection and Information Commissioner shall act as competent supervisory authority insofar as the relevant data transfer is governed by Swiss Data Protection Laws and Regulations.</li>
+</ul>
+
+1.12 **Notification of Government Access Requests.** For the purposes of clause 15(1)(a), Consider.it shall notify Customer only and not the Data Subject(s) in case of government access requests. Customer shall be solely responsible for promptly notifying the Data Subject as necessary.
+
+1.13 **Governing Law.** The governing law for the purposes of clause 17 shall be the law of Ireland. 
+
+1.14 **Choice of forum and jurisdiction.** For the purpose of clause 18 any dispute arising from the Clauses shall be resolved by the courts of Ireland.
+
+1.15 **Appendix.** The Appendix shall be completed as follows:
+* The contents of section 1 of Schedule 2 shall form Annex I.A to the Standard Contractual Clauses; 
+* The contents of sections 2 to 9 of Schedule 2 shall form Annex I.B to the Standard Contractual Clauses;
+* The contents of section 10 of Schedule 2 shall form Annex I.C to the Standard Contractual Clauses; 
+* The contents of section 11 of Schedule 2 shall form Annex II to the Standard Contractual Clauses.
+
+1.16 **Data Exports from the United Kingdom under the Standard Contractual Clauses.** In case of any transfers of Personal Data from the United Kingdom governed by UK Data Protection Laws and Regulations, the Mandatory Clauses of the Approved Addendum being the template Addendum B1.0 issued by the ICO and laid before Parliament in accordance with s119A of the Data Protection Act 2018 on 2 February 2022, as it is revised under Section 18 of those Mandatory Clauses ("Approved Addendum") shall apply. The information required for Tables 1 to 3 of Part One of the Approved Addendum is set out in this Schedule 1 and Schedule 2 of this DPA (as applicable). For the purposes of Table 4 of Part One of the Approved Addendum, neither party may end the Approved Addendum when it changes.
+
+1.17 **Data Exports from Switzerland under the Standard Contractual Clauses.** For data transfers governed by Swiss Data Protection Laws and Regulations, the Standard Contractual Clauses also apply to the transfer of information relating to an identified or identifiable legal entity where such information is protected similarly as Personal Data under Swiss Data Protection Laws and Regulations until such laws are amended to no longer apply to a legal entity and provided Consider.it Processes such data as a Processor.
+
+1.18 **Conflict.** The Standard Contractual Clauses are subject to this DPA and the additional safeguards set out hereunder. The rights and obligations afforded by the Standard Contractual Clauses will be exercised in accordance with this DPA, unless stated otherwise. In the event of any conflict or inconsistency between the body of the DPA and the Standard Contractual Clauses, the Standard Contractual Clauses shall prevail.
+
+
+
+
+
+
+
+## SCHEDULE 2: DESCRIPTION OF PROCESSING / TRANSFER
+
+### 1. LIST OF PARTIES
+
+**Data exporter(s):** _Identity and contact details of the data exporter(s) and, where applicable, of its/their data protection officer and/or representative in the European Union_
+
+Name: 
+
+Address: 
+
+
+Contact person’s name, position and contact details: 
+
+Activities relevant to the data transferred under these clauses: Performance of the Services pursuant to the Agreement.
+
+
+Signature and date:
+
+Role: Controller
+
+
+
+
+**Data importer(s):** _Identity and contact details of the data importer(s), including any contact person with responsibility for data protection_
+
+Name: Consider.it LLC.
+
+Address: 2615 SE 27th Av, Portland OR 97202, USA
+
+Contact person’s name, position and contact details: 
+Travis Kriplean, CEO, travis@consider.it
+
+Activities relevant to the data transferred under these clauses: Performance of the Services pursuant to the Agreement.
+
+
+Signature:
+
+Title: CEO, Consider.it
+
+Role: Processor
+
+
+
+
+
+### 2. CATEGORIES OF DATA SUBJECTS WHOSE PERSONAL DATA IS TRANSFERRED
+
+Customer may submit personal data to the Services, the extent of which is determined and controlled by Customer and which may include, but is not limited to, personal data relating to the following categories of data subject:
+
+* Anyone who accesses a Consider.it forum
+* Authorized Users who register an account
+* Forum hosts who create and/or administer a Consider.it forum
+
+These natural persons may be:
+
+* Stakeholders of Customer (e.g. prospects, customers, business partners, vendors, members, donors, taxpayers, residents, citizens) 
+* Employed by Customer (e.g. employees, agents, advisors, freelancers)
+
+
+
+### 3. CATEGORIES OF PERSONAL DATA TRANSFERRED
+
+The personal data transferred concern the following categories of data: any Personal Data submitted to the Services, the type, extent and detail of which is determined and controlled by Customer in its sole discretion, and which may include, but is not limited to the following categories of Personal Data:
+
+* Name
+* Username
+* Email address
+* Profile picture
+* User generated content (proposals, pros and cons, comments, opinions)
+* Responses to Customer-defined registration survey
+* Connection data (user agent string, IP address, timestamps)
+
+### 4. SPECIAL CATEGORIES OF DATA
+
+Customer may configure Consider.it to collect from Authorized Users who register an account via a survey. The type, extent, and detail of this data is determined and controlled by Customer in its sole discretion, and may include special categories of data including: 
+* race or ethnic origin;
+* political opinions;
+* religious or philosophical beliefs;
+* trade-union membership;
+* genetic or biometric data;
+* health; 
+* income; and
+* sex life.
+
+### 5. FREQUENCY OF THE TRANSFER
+
+The frequency of the transfer (e.g. whether the data is transferred on a one-off or continuous basis): Continuous basis depending on the use of the Services by Customer.
+
+### 6. NATURE OF THE PROCESSING
+The nature of the processing is the performance of the Services pursuant to the Agreement.
+
+### 7. PURPOSE OF PROCESSING, THE DATA TRANSFER AND FURTHER PROCESSING
+
+Consider.it will Process Personal Data as necessary to perform the Services pursuant to the Agreement and as further instructed by Customer in its use of the Services.
+
+### 8. DURATION OF PROCESSING
+
+The period for which the personal data will be retained, or, if that is not possible, the criteria used to determine that period: Subject to section 8 of the DPA, Consider.it will Process Personal Data for the duration of the Agreement, unless otherwise agreed upon in writing.
+
+### 9. SUB-PROCESSOR TRANSFERS
+
+For transfers to (sub-) processors, also specify subject matter, nature and duration of the processing: As per 7 above, the Sub-processor will Process Personal Data as necessary to perform the Services pursuant to the Agreement. Subject to section 8 of the DPA, the Sub-processor will Process Personal Data for the duration of the Agreement, unless otherwise agreed in writing.
+
+Identities of the Sub-processors used for the provision of the Services and their country of location are listed under the Sub-processor Lists accessible via https://consider.it/docs/legal/subprocessors.
+
+### 10. COMPETENT SUPERVISORY AUTHORITY
+
+Identify the competent supervisory authority/ies in accordance with clause 13:
+
+* Where the data exporter is established in an EU Member State: The supervisory authority with responsibility for ensuring compliance by the data exporter with Regulation (EU) 2016/679 as regards the data transfer shall act as competent supervisory authority.
+
+* Where the data exporter is not established in an EU Member State, but falls within the territorial scope of application of Regulation (EU) 2016/679 in accordance with its Article 3(2) and has appointed a representative pursuant to Article 27(1) of Regulation (EU) 2016/679: The supervisory authority of the Member State in which the representative within the meaning of Article 27(1) of Regulation (EU) 2016/679 is established shall act as the competent supervisory authority.
+
+* Where the data exporter is not established in an EU Member State, but falls within the territorial scope of application of Regulation (EU) 2016/679 in accordance with its Article 3(2) without however having to appoint a representative pursuant to Article 27(2) of Regulation (EU) 2016/679: the Irish Data Protection Commission shall act as the competent supervisory authority.
+
+* Where the data exporter is established in the United Kingdom or falls within the territorial scope of application, the Information Commissioner’s Office Shall Act as the competent supervisory authority.
+Where the data exporter is established in Switzerland or falls within the territorial scope of application the Swiss Federal Data Protection and Information Commissioner shall act as competent supervisory authority.
+
+
+### 11. TECHNICAL AND ORGANISATIONAL MEASURES
+
+Data importer will maintain administrative, physical, and technical safeguards for protection of the security, confidentiality and integrity of Personal Data uploaded to the Services, as described in the [Security Practices Documentation](/docs/legal/security) applicable to the specific Services purchased by data exporter, and currently accessible at https://consider.it/docs/legal/security or otherwise made reasonably available by data importer. Data importer will not materially decrease the overall security of the Services during a subscription term. Data Subject Requests shall be handled in accordance with section 3 of the DPA.
+
+
+
+
+
+

--- a/public/docs/deleting_your_data.md
+++ b/public/docs/deleting_your_data.md
@@ -1,0 +1,32 @@
+Accessing, Correcting, or Deleting Your Information
+===================================================
+Updated: February 2023
+
+You can review and change your personal information by logging into our Services and visiting your user profile page.
+
+If the information you wish to access is not displayed there, you may also send us an email at [hello@consider.it](mailto:hello@consider.it) to request access to, or correct any personal information that you have provided to us. Sometimes we cannot delete your personal information except by also deleting your user account. We may not accommodate a request to change information if we believe the change would violate any law or legal requirement or cause the information to be incorrect.
+
+Deleting content
+----------------
+<a name="deleting-content"></a>
+
+You can delete Content you've posted to our Services.
+
+In some cases, because you may have created posts that other users have referenced, any Content that may be lawfully retained and displayed will continue to be visible through the Services and retained by us, in an anonymized form. If your posts continue to be visible, they will be entirely anonymized and disassociated with your account.
+
+If you delete your Content from the Services, copies of your Content may remain viewable in cached and archived pages, or might have been copied or stored by other users of the Service. 
+
+
+Deleting your account
+---------------------
+
+You may delete your account by either 
+1) Using the account deletion button in your Consider.it profile
+2) By emailing a request for deletion to [hello@consider.it](mailto:hello@consider.it). 
+
+When your account is deleted, all content you have posted is also deleted or anonymized, as described above.
+
+**Data can’t be recovered once it has been deleted.** 
+
+
+

--- a/public/docs/privacy_policy.md
+++ b/public/docs/privacy_policy.md
@@ -1,0 +1,227 @@
+Consider.it Privacy Policy
+================================
+Updated: February 2023
+
+
+This privacy policy outlines how we handle the data you entrust to us. We want you to understand how and why Consider.it LLC (“Consider.it”, “we”, or “us”) collects, uses and shares information about you when you access and use Consider.it’s site and services (collectively, the “Services”) or when you otherwise interact with us.
+
+And we want you to understand your rights to your data. **Your data continues to be owned by you.** Not us, nor your forum host.
+
+Furthermore, we want to emphasize our promise to you that **we will never sell your data to third parties**, such as for targeted advertising or to a data aggregator. 
+
+Throughout this policy, we make reference to Forum Hosts (or "Hosts"). In our Services, Forum Hosts are the people (who may or may not be representing an organization) who create a new Consider.it forum, who control the configuration of that forum, and who make other administrative decisions (e.g. content moderation). In addition to these [Terms of Service](/docs/legal/terms_of_service), Forum Hosts are bound by our [Forum Hosting Terms](/docs/legal/standard_hosting_terms).
+
+Information we collect about you
+--------------------------------
+
+Information we collect about you may include, depending on the service:
+
+### Information regarding your account
+
+We collect the information you provide when you use our Services. This includes basic information used to create your account (e.g., a username, password, email address, and profile picture). 
+
+An email address is collected to (1) make it harder for someone to register multiple accounts, (2) give a unique identifier to an account, and (3) provide a way for Consider.it to send email notifications about subsequent activity in the forum. There are other less common ways in which we may use your email address to perform our services, such as reaching out to you if we discover that an error in Consider.it software interferred with your ability to participate in a forum. 
+
+### Other information you may provide at the Forum Host's request
+<a name="host-questions"></a>
+
+The Forum Host (or Hosts) of a particular Consider.it forum may configure additional optional or required questions to ask you during the account registration process. For example, demographic questions like your age, gender, race, or income. This information can help hosts for a number of reasons, such as understanding if they're reaching the communities they're seeking to engage or understanding differences in how subgroups are responding to particular proposals.  
+
+The Forum Host chooses whether the information provided for each question is visible only to the Hosts of the forum or whether the information is visible to anyone who participates in the forum. 
+
+At any point, you can edit your responses to these questions in your user profile. However, if a Host specifies that a question is required for your participation, it must be answered. You can, however, withdraw from the forum by [deleting your account](/docs/legal/deleting_your_data) (also an option in your profile).
+
+If you feel that a Forum Host is asking inappropriate and/or intrusive questions without a reasonable way to opt-out, please report it to [help@consider.it](mailto:help@consider.it).
+
+### Content you share
+<a name="content-you-share"></a>
+
+Consider.it allows users to post content, including proposals, points, comments, photos, links and other materials. Anything that a user posts or otherwise makes available on our Services is referred to as “Content.” We collect the Content you post to the Services, such as opinions you give, the proposals, points and comments you write, both in public and in private Consider.it Forums. The opinions you submit by e.g. dragging sliders, is also considered posted Content.
+
+### Geolocation data
+<a name="geolocation-data"></a>
+
+We log access to all accounts by full IP address so that we can verify no unauthorized access has happened recently. This login data is deleted after our logs are rotated out. This takes no more than a year. We also may log full IP addresses used to sign up for an account. 
+
+Web analytics data, described in the next section, are also tied temporarily to IP addresses to assist with troubleshooting and for identifying coordinated or malicious network activity.
+
+### Website interactions
+
+When you browse our marketing pages or applications, your browser automatically shares certain information such as which operating system and browser version you are using. We track that information, along with the pages you are visiting, page load timing, and which website referred you for statistical purposes like conversion rates and to test new designs. We sometimes track specific link clicks to help inform some design decisions. These web analytics data are tied to a truncated version of your IP address and, when you are signed into our Services, your user account.
+
+### Anti-bot measures
+<a name="anti-bot-measures"></a>
+
+We may use [CAPTCHA](https://en.wikipedia.org/wiki/CAPTCHA) services to reduce the risk of bot-based attacks on our system (spamming, multiple account creation to hijack a forum, and brute force login). We have a legitimate interest in protecting our apps and the broader Internet community from these attacks. When we implement CAPTCHAs during account registration, the CAPTCHA service will take various information into account when decided whether the data is likely to be filled out by an automated program (e.g IP address, how long the visitor has been on the app, mouse movements).
+
+### Cookies
+
+A cookie is a piece of text stored by your browser to help it remember your login information, site preferences, and more. **In Consider.it, we only use persistent first-party cookies for storing session data** (i.e. a logged-in account so you don't have to login each time you visit the Site or refresh the page). All other cookies are strictly opt-in.
+
+You can adjust cookie retention settings in your own browser. To learn more about cookies, including how to view which cookies have been set and how to manage and delete them, please visit: [www.allaboutcookies.org](https://www.allaboutcookies.org).
+
+### Voluntary correspondence
+
+If you contact us with a question or to ask for help, or respond to an inquiry by us, we keep that correspondence, including the email address, so that we have a history of past correspondences to reference if you reach out in the future.
+
+### Billing information
+
+If you decide to pay for a Consider.it product, we ask for your credit card and billing address. That’s so we can charge you for service, calculate taxes due, and send you invoices. Your name, billing address, organization name, billing information, and credit card information is handled by our payment processor.
+
+### Information we do not collect
+
+We don’t collect any characteristics of protected classifications including age, race, gender, religion, sexual orientation, gender identity, gender expression, or physical and mental abilities or disabilities **unless a Forum Host configures a forum to do so during the account registration mini-survey**. In that case, you may provide this data voluntarily, or not use that forum.
+
+We also do not collect any biometric data. You may choose to provide a profile picture that is a real picture of you, but that is your choice. We do not derive any information from profile pictures, they are just used to enliven the forum.
+
+### Children Under the Age of 13
+
+Our Services are not intended for children under 13 years of age. No one under age 13 may provide any information to or on the Services. We do not knowingly collect personal information from children under 13. If you are under 13, do not use or provide any information on these Services or on or through any of its features/register on the Services, make any purchases through the Services, use any of the interactive or public comment features of the Services or provide any information about yourself to us, including your name, address, telephone number, email address, or any screen name or user name you may use.
+
+If we learn we have collected or received personal information from a child under 13 without verification of parental consent, we will delete that information. If you believe we might have any information from or about a child under 13, please contact us at [hello@consider.it](mailto:hello@consider.it).
+
+
+
+How we use information about you
+--------------------------------
+
+We believe the following is a complete accounting of how we use information about you. However, because unexpected situations do arise, we do not claim that the following is an exhaustive list of how we use your personal data. 
+
+
+### Provide and maintain the Services
+
+As a dialogue and deliberation platform, we store and process Content you share in the forum, including proposals, comments, opinions, files, and images. We continue to store and process this Content until either you [delete your account](/docs/legal/deleting_your_data), you delete your data on a particular forum, or the forum host requests the forum to be deleted. 
+
+We also store and process your user profile, including your name, email address, profile photo, and password. This information can make a user personally identifiable, although you can use a pseudonym and anonymous email address to prevent this. Your password is never stored in cleartext; rather, it is [salted and hashed](https://en.wikipedia.org/wiki/Salt_(cryptography)) so that no one can deduce your password. 
+
+### To improve the Services
+
+Sometimes we use your data to help us fix software errors, either that we discover ourselves, that are reported to us by you or others, or that are identified through a machine-generated notification of an error. In some cases we will access your email address to communicate with you about an error we can see you experienced. 
+
+We also use forum data in our software development environments so that we can develop new functionality. The forum data we use is anonymized: names, email addresses, and other personal information is randomized. We only use forum data from our US-based server.
+
+### To protect the safety of Consider.it and our users
+
+This includes, but is not limited to, blocking suspected [spammers](#geolocation-data), [bots](#anti-bot-measures), addressing abuse, and enforcing the [Terms of Service](/docs/legal/terms_of_service). If we do discover you are using our products for a [restricted purpose](/docs/legal/use_restrictions), we may report the incident to the appropriate authorities.
+
+### Promote our Services using Content that you share in public forums
+
+This mainly means that in the course of marketing our Services, we reserve the right to link to a public forum in which you participated. 
+
+We will not specifically quote any content you have shared in a forum without asking your permission and receiving written consent. 
+
+### Other uses
+* Send you technical notices, updates, security alerts, and other support and administrative messages
+* Communicate with you about Consider.it news and information we think be of interest to you
+* Monitor and analyze trends, usage, and activities in connection with our Services
+
+
+How we share information
+------------------------
+
+We don't sell your information to third parties. Our business model is to get paid by Forum Hosts to help them engage their communities. It is a straightforward relationship. 
+
+We believe the following is a complete accounting of how we share information about you with other entities. However, because unexpected situations do arise, we do not claim that the following is an exhaustive list of how we share your personal data. 
+
+
+### While providing the Services
+
+In the course of providing dialogue and deliberation Services, certain information will be shared with other users and the public. 
+
+In public Forums, proposals, points, comments, usernames, and other Content you post are viewable by the public at large. 
+
+In private Forums, proposals, points, comments, usernames and other Content you post are only viewable by invited members of the respective private Forum. In order to enter a private Forum, a user must log in with his or her proper credentials. Note that Hosts can at a later time turn a private forum into a public forum. You should take that into consideration before posting Content to the Services. 
+
+Any data collected by the Host during registration that they have marked as visible to other forum users is also accessible to those other forum users. 
+
+We also store and process your user profile. Your email address will only be shared, [under some conditions](#sharing-data-with-hosts), with the hosts of the forum, and never with other users or visitors to the forum, unless you explicitly enter your email address into a field where we're not asking for an email address. 
+
+#### Subprocessors 
+
+Though we try to keep it to a minimum, we do use some third-party services to carry out our Services (e.g. our hosted server provider). These services may process information you provided during the registration process or content you post. You can view the [list of third-party services we use](/docs/legal/subprocessors). We also use some other processors for some business functions (like our email provider), which you can see at [the same link](/docs/legal/subprocessors).
+
+
+### When sharing data with Forum Hosts
+
+<a name="sharing-data-with-hosts"></a>
+
+A Host of a paid Consider.it forum is considered a first-party to the data we collect on their behalf in the respective forum. Specifically, we give Hosts of paid forums the option to export data containing (a) Content created in the Forum, linked to the account information of the user who created it and (b) Account information about users of the forum including but not limited to demographic data and personal contact information; and (c) other related data.
+
+Note that [Forum Hosts have additional use restrictions](/docs/legal/use_restrictions#additional-restrictions-for-hosts), including a restriction to not sell Personal Data collected from Consider.it's export data functionality to a third party. 
+
+#### Public Records
+
+If the Host is a government entity or other public body, any communication via the Services (whether by a government representative, your, or the general public) may be considered a “public record” in the jurisdiction of the Host, and, as such, may be subject to monitoring and retention by the Host, and disclosure to third parties.
+
+### When required under applicable law
+
+Consider.it is based in the U.S., and also has data infrastructure in the EU and Canada. There are circumstances in which Consider.it will divulge your Personal Information when formally required by law, regulation, or litigation. If we are audited by a tax authority, we may be required to share billing-related information. If that happens, we only share the bare minimum needed such as billing addresses and tax exemption information.
+
+
+Data retention
+--------------
+
+We continue to retain data that you provide to a forum until the Forum Host terminates their agreement with us, or until you [delete your account or delete your data for a particular forum](/docs/legal/deleting_your_data). This is because often a Consider.it forum continues to serve as a transparent public account for a community about what its members think about the topics discussed, one of the primary value propositions of our Services. 
+
+
+How we secure your data
+-----------------------
+
+We take reasonable measures to help protect information about you from loss, theft, misuse and unauthorized access, disclosure, alteration, and destruction. For example, we do not directly store your password on our server; instead we store a salted password that is then encrypted using a cryptographic hash function.
+
+Location of data
+----------------
+
+Forum Hosts have the option to create the respective forum on our infrastructure primarily based in either the US, the EU, or Canada. This impacts the primary location where we store and process your data. For example, if the forum you're participating in is hosted in the EU, our cloud computing services are all also based in the EU. See our [subprocessors](/docs/legal/subprocessors) for more information. 
+
+So please be aware that any information you provide to us will be transferred to, stored, and processed in the location of the regional service. By using our service, participating in any of our services and/or providing us with your information, you consent to this transfer.
+
+
+Your rights regarding your personal data
+----------------------------------------
+
+We strive to uphold the data rights for all Consider.it users, regardless of your location, articulated in the most stringent privacy regulations around the world, specifically the EU's [General Data Protection Regulation](https://gdpr-info.eu/) (GDPR) and the [California Consumer Privacy Act](https://oag.ca.gov/privacy/ccpa) (CCPA). We recognize all the rights granted in these regulations, except as limited by applicable law. The rights are:
+
+*   **The right to be informed.** You have the right to know what personal information is collected, used, shared or sold. We outline both the categories and some specific data we collect, as well as how they are used, in this privacy policy. You also have the right to know the data retention policy. 
+*   **The right of access.** This includes your right to access the personal information we gather about you, and your right to obtain information about the sharing, storage, security and processing of that information.
+*   **The right to correction.** You have the right to request prompt correction of your personal information. This is almost always possible by editing your user profile, but if not, you can contact us.
+*   **The right to object to processing.** You have the right to object to how or why your personal information is processed, in some circumstances.
+*   **The right to not be subject to automated decision-making.** You have the right to object and prevent any decision that could have a legal, or similarly significant, effect on you from being made solely based on automated processes. This right is limited, however, if the decision is necessary for performance of any contract between you and us, is allowed by applicable law, or is based on your explicit consent.
+*   **The right to be forgotten.** This is your right to request, subject to certain limitations under applicable law, that your personal information be erased from our possession and, by extension, all of our service providers. Fulfillment of some data deletion requests may prevent you from using our services because our applications may then no longer work. In such cases, a data deletion request may result in closing your account.
+*   **The right to portability.** You have the right to receive the personal information we have about you and the right to transmit it to another party.
+*   **The right to restrict processing.** This is your right to request restriction of how and why your personal information is used or processed, including opting out of sale of personal information (which we never have and never will do).
+*   **The right to non-discrimination.** We do not and will not charge you a different amount to use our products, offer you different discounts, or give you a lower level of customer service because you have exercised your data privacy rights. However, the exercise of certain rights (such as the right “to be forgotten”) may prevent you from using our Services.
+*   **The right to complain.** You have the right to make a complaint regarding our handling of your personal information with the appropriate supervisory authority. 
+
+You can exercise many of these rights by directly editing information or taking action in your user profile, and by reading this Privacy Policy, [Terms of Service](/docs/legal/terms_of_service), and the other linked documents. 
+
+You may also exercise the above rights by contacting us at [help@consider.it](mailto:help@consider.it) and provide specific and detailed information about your request necessary for us to respond to and carry out your request. Note that if an authorized agent is corresponding on your behalf, we will first need written consent with a signature from the account holder before proceeding.
+
+**If you wish to register a complaint, please contact us at [help@consider.it](mailto:help@consider.it).** Alternatively, if you are in the EU, you can [identify your specific authority to file a complaint or find out more about GDPR](https://edpb.europa.eu/about-edpb/board/members_en).
+
+
+### Accessing, Correcting, or Deleting Your Information
+
+You can access, review, and change your personal information by logging into Services and visiting your user profile page. You can also delete your account from your user profile page. More information is available about [accessing, correcting, or deleting your information](/docs/legal/deleting_your_data), and that information is part of this privacy policy. 
+
+
+When transferring personal data from the EU
+-------------------------------------------
+
+The GDPR requires that any data transferred out of the EU must be treated with the same level of protection that the EU privacy laws grant. We have worked hard to minimize the times when EU personal data is transferred out of the EU by (1) minimizing our subprocessors (organizations with whom we task with carrying out data processing) and (2) working with subprocessors with operations in the EU. You can inspect our subprocessors and where their operations are, in our [subprocessor documentation](/docs/legal/subprocessors). 
+
+To cover the few cases where your personal data may be transferred out of the EU, Consider.it offers a [Data Processing Addendum](/docs/legal/data_processing_addendum) (DPA) to protect it. This DPA is incorporated into our [Forum Host Terms of Service](/docs/legal/standard_hosting_terms) to govern our processing of your data on behalf of the Forum Host (the data controller). The DPA includes the European Commission’s updated Standard Contractual Clauses to extend GDPR privacy principles, rights, and obligations everywhere personal data is processed. 
+
+There are also a few ad-hoc cases where EU personal data may be transferred to the US related to Consider.it LLC operations. Such transfers are only occasional and transferred under the Article 49(1)(b) derogation under GDPR. These data transfers mostly occur through direct email correspondance with us, for example, if we respond to a support request from you. 
+
+
+
+Changes
+-------
+
+We will change this Privacy Policy from time to time. When we do, we will revise the date at the top of the policy. As of January 2023, our legal policies will be available [on GitHub](https://github.com/Considerit/ConsiderIt/tree/master/public/docs), where you can review all changes that have been made over time. We encourage you to review the Privacy Policy whenever you access or use our Services or otherwise interact with us to stay informed about our information practices and the ways you can help protect your privacy. If you continue to use our Services after Privacy Policy changes go into effect, you consent to the revised policy.
+
+Contact Us
+----------
+
+If you have any questions about this Privacy Policy, please email [hello@consider.it](mailto:hello@consider.it).

--- a/public/docs/security.md
+++ b/public/docs/security.md
@@ -1,0 +1,140 @@
+Security Practices at Consider.it
+===================================
+Updated: February 2023
+
+* We will never (and have never) sold customer data to third parties. We have a straightforward relationship with Forum Hosts where they may pay us to host a Consider.it forum on their behalf. This allows us to be stringent on minimizing the data we collect from you. 
+* We don't run ads, and only use cookie-less privacy-first analytics. This means that intrusive tracking of you is absent in Consider.it. 
+* Our services, running on secure cloud-hosted servers, have many security measures in place to protect your data and prevent unauthorized access. We routinely conduct internal security audits.
+* We try to minimize access to your data, with the exception of supporting the resolution of a problem with the system. 
+* We treat all customer information and data as confidential, except for situations where a customer has explicitly made the information publicly accessible.
+* Data is backed up in multiple ways, daily, and stored in multiple locations.
+* We have independent regional servers in the United States, European Union, and Canada. Hosts can choose the regional server to use to help reduce cross-border data transfers.
+* You can track the status of Consider.it's services at [https://status.consider.it](https://status.consider.it).
+
+
+The information below gives more details about our technical and organizational security measures. The information is formatted to address the requirements set out by the EU's stringent data protection law, the General Data Protection Regulation (GDPR). Furthermore, this information is incorporated into our [Data Processing Addendum](/docs/legal/data_processing_addendum), which is in effect when the GDPR applies to your use of Consider.it. Even if your use is not covered under the GDPR, we seek to live up to those standards.
+
+
+<table><tbody>
+  <tr>
+    <td><strong>Measure</strong></td>
+    <td><strong>Description</strong></td>
+  </tr><tr>
+    <td>Measures of pseudonymisation and encryption of Personal Data</td>
+    <td>
+      <ul>
+        <li>Employee laptops are encrypted using full disk AES-256 encryption.</li>
+        <li>HTTPS encryption on every web interface, using industry standard algorithms and certificates.</li>
+        <li>Secure transmission of all traffic, internal and external, using by default TLS 1.2 or better.</li>
+        <li>Access to operational environments via SSH enabled only with public-private RSA keys.</li>
+        <li>Database backups that reside in Amazon Web Services (AWS) S3 is encrypted at rest as stated in AWS' documentation and whitepapers.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td>Measures for ensuring ongoing confidentiality, integrity, availability and resilience of processing systems and services</td>
+    <td>On our Linode servers, Consider.it uses vulnerability assessment, automatic security patching, threat protection technologies, and routine monitoring procedures designed to identify, assess, mitigate and protect against identified security threats, viruses, and other malicious code.
+    <p style="margin-top: 12px">Consider.it also uses <a href="https://betteruptime.com/">Better Uptime</a> to track service uptime and alert us if a particular system fails. We also employ Better Uptime’s heartbeat monitors for making sure offline processing services continue to function, like email notification runners and database backups. Anyone can see the current status of Consider.it servers at any time by visiting <a href="https://status.consider.it">status.consider.it</a>. In addition, consider.it generates email alerts for application errors (e.g. if the database connection is dropped).</p>
+    </td></tr>
+
+  <tr>    
+    <td>Measures for ensuring the ability to restore the availability and access to Personal Data in a timely manner in the event of a physical or technical incident</td>
+    <td>
+      In the case of a physical or technical incident, Consider.it has multiple sources of backups to restore personal data from. Specifically: <ul style="margin-top: 12px;">
+        <li>Consider.it is hosted in the cloud on <a href="https://linode.com">Linode</a> servers. Linode makes backup images of the entire server daily and stores them securely on a different Linode server. These backup images can be used to restore data and services in the case of catastrophic failure.</li> 
+        <li>The Consider.it server creates database backups every four hours, stores them on Amazon AWS S3 (encrypted in transit and at rest), and deletes them from the Consider.it server after transmission. These database backups can be used to restore data in the case of database failure or corruption.</li>
+      </ul>
+    </td></tr>
+  <tr>    
+    <td>Processes for regularly testing, assessing and evaluating the effectiveness of technical and organisational measures in order to ensure the security of the processing</td>
+    <td>
+    <ul>
+      <li>Internal comprehensive security audits are conducted quarterly.</li>
+      <li>System access logs are maintained for at least one year to facilitate investigations if necessary.</li>
+      <li>Regular vulnerability scans and configuration scans are run at least quarterly, with any findings addressed within identified timeframes based on severity.</li>
+      <li>Static Analysis tools are used to identify security flaws during the development of       software.</li>
+    </ul>
+    </td></tr>
+  <tr>    
+    <td>Measures for user identification and authorisation</td>
+    <td>
+    <ul>
+      <li>Access to operational and production servers is only facilitated through the Secure Shell Protocol (SSH) using public-key cryptography. Password-based login is disabled. All access attempts, successful and unsuccessful are logged and examined by automated processes for suspicious patterns.</li>
+      <li>Login to cloud service provider accounts is protected by two-factor authentication.</li>
+      <li>Authentication of users in Consider.it itself is facilitated through email and password. Only certain accounts are authorized as hosts of Consider.it forums, and those accounts are protected via password.</li>
+    </ul>
+    </td></tr>
+  <tr>    
+    <td>Measures for the protection of data during transmission</td>
+    <td>Data in transit is protected by Transport Layer Security (“TLS”) 1.2 or greater.</td></tr>
+  <tr>    
+    <td>Measures for the protection of data during storage</td>
+    <td>
+    <ul>
+      <li>Personal Data retained internally on our Linode servers are protected via the access control measures for our operational and production servers described earlier. All production instances additionally have endpoint security software (e.g. aggressive firewall, malicious actor detection, automated banning of suspicious activity) which is monitored for unusual or problematic activity. Measures are in place to ensure unauthorized actors are not permitted to access unauthorized data. System inputs are recorded via log files.</li>
+      <li> Backups of Personal Data stored by our subprocessors (Linode and AWS) are encrypted at rest and covered by their respective certifications. Backups are encrypted during transmission to these subprocessors.</li>
+    </ul>
+    </td>
+    </tr>
+  <tr>    
+    <td>Measures for ensuring physical security of locations at which Personal Data are processed</td>
+    <td>The Processor utilises third party data centres that maintain current ISO 27001 certifications and/or SSAE 16 SOC 1 Type II or SOC 2 Attestation Reports. The Processor will not utilise third party data centres that do not maintain the aforementioned certifications and/or attestations, or other substantially similar or equivalent certifications and/or attestations.</td></tr>
+  <tr>    
+    <td>Measures for ensuring events logging</td>
+    <td>System inputs are recorded in the form of log files therefore it is possible to review retroactively whether and by whom Personal Data was entered, altered or deleted. Logs are rotated and deleted, so there is a limit to how far back in history we can look.</td></tr>
+  <tr>    
+    <td>Measures for ensuring system configuration, including default configuration</td>
+    <td>System configuration is applied and maintained by software tools that ensure the system configurations do not deviate from the specifications.
+  </td></tr>
+  <tr>    
+    <td>Measures for internal IT and IT security governance and management</td>
+    <td>Employees are instructed to collect, process and use Personal Data only within the framework and for the purposes of their duties (e.g. service provision). At a technical level, there is appropriate separation of testing and production systems. A quarterly internal security audit is carried out to review code and logs and to validate existing procedures.
+    </td></tr>
+  <tr>    
+    <td>Measures for certification/assurance of processes and products</td>
+    <td>The Processor utilises third party data centres and cloud computing services that maintain current ISO 27001 certifications and/or SSAE 16 SOC 1 Type II or SOC 2 Attestation Reports. The Processor will not utilise third party data centres that do not maintain the aforementioned certifications and/or attestations, or other substantially similar or equivalent certifications and/or attestations. 
+      <br><br>
+      Consider.it itself does not maintain a security certification of its processes and products, but will cooperate with the Controller (upon written request, and no more than once in any 12 month period), to carry out a third-party security audit and/or certification at Controller's expense. Any audit report submitted to the Controller shall be treated as Confidential Information and subject to the confidentiality provisions of the Agreement between the parties</td></tr>
+  <tr>    
+    <td>Measures for ensuring data minimisation</td>
+    <td>
+    <ul>
+      <li>Data collection is limited to the purposes of processing, or the data that the controller chooses to ask for and which a data subject chooses to provide.</li>
+      <li>Security measures are in place to provide only the minimum amount of access necessary to
+      perform required functions.</li>
+    </ul>
+    </td></tr>
+  <tr>    
+    <td>Measures for ensuring data quality</td>
+    <td>
+    <ul>
+      <li>Consider.it has a process that allows individuals to exercise their privacy rights (including a right to <a href="/docs/legal/deleting_your_data">amend and update information</a>), as described in Consider.it's <a href="/docs/legal/privacy_policy">Privacy Policy</a>.</li>
+      <li>Before deploying new application code to production environments, we thoroughly test the new functionality.</li>
+      <li>If application errors are identified through further testing or automated error reporting, we address the problem and assess its impact. To the extent possible, we reach out to affected participants to give them an opportunity to address any problems with their data that may have originated from the error.</li>
+    </ul>
+    </td></tr>
+  <tr>    
+    <td>Measures for ensuring limited data retention</td>
+    <td>
+    <p>Controllers may request deletion of all data, including Personal Data, relating to a Consider.it forum, at any time. Data subjects may request deletion of all of their Personal Data, at any time. These data deletion requests are promptly (and usually immediately) honored. It should be noted that with these deletions, Personal Data may remain in the database backups and logs until they are rotated out of storage.</p>
+      <p style="margin-top:12px">Database backups are rotated and retained individually for no more than 6 months. System and application log files are rotated and retained individually for no more than one year. Our retention policy with these backups and logs is a balance between security analysis & ensuring data quality, and data retention.</p>
+    </ul>
+    </td></tr>
+  <tr>    
+    <td>Measures for ensuring accountability</td>
+    <td>
+    <ul>
+      <li>All employees that handle sensitive data must acknowledge the information security policies.</li>
+      <li>Data protection impact assessments are part of any new processing initiative.</li>
+      <li>When working with a Controller who wishes to instruct Consider.it to collect potentially sensitive Personal Data, we encourage them to conduct a data protection impact assessment.</li>
+    </ul>
+    </td></tr>
+  <tr>    
+    <td>Measures for allowing data portability and ensuring erasure</td>
+    <td>Controllers may request deletion of all data relating to a Consider.it forum, including Personal Data, at any time. Data subjects may request deletion of all of their Personal Data, at any time. These data deletion requests are promptly (and usually immediately) honored. The Services have built-in tools that allows a data subject to permanently erase their data. Data subjects may also request an export of their Personal Data. 
+    </td></tr>
+  <tr>    
+    <td>Measures to be taken by the (Sub-) processor to be able to provide assistance to the Controller (and, for transfers from a Processor to a Sub-processor, to the Data Exporter).</td>
+    <td>The technical and organizational measures that the data importer will impose on sub-processors are described in the <a href="/docs/legal/data_processing_addendum">Data Processing Addendum</a>.</td></tr>
+  </tbody>
+</table>

--- a/public/docs/standard_hosting_terms.md
+++ b/public/docs/standard_hosting_terms.md
@@ -1,0 +1,410 @@
+Consider.it Forum Hosting Terms
+===============================
+Updated: February 2023
+
+
+Thanks for hosting a Consider.it forum! These Forum Hosting Terms help us clarify our relationship, in the form of a legal contract between us ("Consider.it LLC") and you ("Customer", "Forum Host"). Customer is an individual or several individuals who have created and/or administer a Consider.it forum, utilizing Consider.it's Hosting Services. Customer may or may not be representing an organization, and may or may not have paid for the use of Consider.it's Hosting Services. 
+
+These Consider.it Forum Hosting Terms, the [Terms of Service](/docs/legal/terms_of_service), the [Data Processing Addendum](/docs/legal/data_processing_addendum) (if applicable), the Service Plan of the respective plan described at [https://consider.it](https://consider.it/pricing), and any additional contract signed by both parties, make up the agreement between Consider.it LLC and Customer.
+
+
+
+Background
+----------
+
+1.  Consider.it LLC develops Consider.it, a computer software platform for running Internet deliberation forums.
+2.  Consider.it LLC releases Consider.it as open source software that anyone can use and change, for free. Specifically, Consider.it LLC licenses Consider.it under the terms of the GNU Affero General Public License v3.0.
+3.  Consider.it LLC offers its familiarity and expertise with Consider.it to host the open source Consider.it platform and to maintain Internet discussion forums for customers. Consider.it LLC administers servers in a data center for doing so. Some of these customers pay Consider.it LLC to use additional features in their Consider.it forums. 
+4.  This is an agreement for Consider.it LLC to host an Internet discussion forum, Customer’s Forum, using Consider.it on Customer's behalf.
+
+Consider.it LLC’s Obligations
+-----------------------------
+<a name="considerit-obligations"></a>
+
+### Host Customer’s Forum
+
+While this agreement continues, Consider.it LLC agrees to run Consider.it so that Users can use the Feature Set on Customer’s Forum, within the Use Limits agreed in the Service Plan. This is termed the “Hosting Services”.
+
+### Configure Consider.it
+
+Consider.it LLC agrees to configure Consider.it to the extent agreed to in the Service Plan.
+
+### Ensure Service Levels
+
+#### Service-Level Agreement
+
+_Uptime Guarantee_. While this agreement continues, so long as Customer’s Forum remains within the Use Limits, Consider.it LLC agrees to host Customer’s Forum with Uptime of no less than the Uptime Commitment expressed in the Service Level as a percentage.
+
+_Respond to Customer Support Requests_. Consider.it LLC agrees to respond to Customer Support Requests from Customer Personnel to [hello@consider.it](mailto:hello@consider.it) about configuration of, use of, and problems with Customer’s Forum, on weekdays that are not public holidays, during working hours (Pacific Time Zone). A response will acknowledge the issue, classify its severity (low, medium, high), and give notice of whether and when it will be addressed. All support requests that demonstrate a failure to meet the Service Plan will receive at least a Medium severity rating. A complete response may first require Customer to provide additional information. Some Service Levels provide a Support Request Response Commitment to respond within a certain number of days, as well as an escalation path.
+
+_Resolve Customer Support Requests_. A Customer Support Request is resolved when Consider.it LLC determines that the underlying issue has been resolved, or that the request falls outside the scope of the Service Plan. Some Service Levels provide a Support Request Resolution Commitment to resolve a Customer Support Request within a certain number of days.
+
+#### Service Levels
+
+The following are the available Service Levels that Consider.it LLC may agree to. The Service Level is Service Level 0, unless superseded by a different contract or specified by the Service Plan. Note that these only cover our _guarantees_; we strive to address any issue as soon as possible, regardless of Service Level.
+
+##### Service Level 0
+
+Uptime Commitment: 98%.
+
+Support Request Response Commitment: None.
+
+Support Request Resolution Commitment: None.
+
+##### Service Level 1
+
+Uptime Commitment: 99%.
+
+Support Request Response Commitment: 3 business days.
+
+Support Request Resolution Commitment:
+* Low Severity: No commitment
+* Medium Severity: 10 business days
+* High Severity: 6 business days
+
+##### Service Level 2
+
+Uptime Commitment: 99.5%.
+
+Support Request Response Commitment: 1 business day. Escalation path to CEO available via text and email.
+
+Support Request Resolution Commitment:
+* Low Severity: No commitment
+* Medium Severity: 4 business days
+* High Severity: 1 business day
+
+#### Remedies
+
+Remedies cannot exceed 100% of the Fees that Customer paid for the Hosting Services in the Hosting Period.
+
+##### Low Uptime
+
+Consider.it LLC agrees to refund Customer’s account on Notice and verification that Consider.it LLC failed to provide the Uptime Commitment according to the Service-Level Agreement for the current contract:
+
+1.  15% of all Fees that Customer paid for the Hosting Services for the Hosting Period with Uptime between zero and one percentage point less than the Uptime Commitment
+2.  25% of all Fees that Customer paid for the Hosting Services for the Hosting Period with Uptime between one and two percentage points less than the Uptime Commitment
+3.  75% of all Fees that Customer paid for the Hosting Services for the Hosting Period with Uptime at or below three percentage points less than the Uptime Commitment
+
+##### Support Response Failure
+
+Consider.it LLC agrees to refund Customer’s account on Notice and verification that Consider.it LLC failed to respond to Customer Support Requests within the Support Request Response Commitment according to the Service-Level Agreement for the current contract:
+
+1.  10% of all Fees that Customer paid for the Hosting Services for the Hosting Period if a response was not received by Customer between 0 and 8 business hours after the guaranteed period.
+2.  30% of all Fees that Customer paid for the Hosting Services for the Hosting Period if a response was not received by Customer between 8 and 24 business hours after the guaranteed period.
+3.  100% of all Fees that Customer paid for the Hosting Services for the Hosting Period if a response was not received by Customer more than 24 business hours after the guaranteed period.
+
+##### Support Resolution Failure
+
+Consider.it LLC agrees to refund Customer’s account on Notice and verification that Consider.it LLC failed to resolve a Customer Support Request within the guaranteed resolution period defined by the Support Request Resolution Commitment according to the Service-Level Agreement for the current contract. The resolution period begins when Consider.it LLC gives its response to a Customer Service Request, and resets if the Customer later provides new information pertinent to resolving the Support Request.
+
+*   100% of all Fees that Customer paid for the Hosting Services for the Hosting Period if a High severity issue is not resolved within the resolution period.
+*   50% of all Fees that Customer paid for the Hosting Services for the Hosting Period if a Medium severity issue is not resolved within the resolution period.
+*   10% of all Fees that Customer paid for the Hosting Services for the Hosting Period if a Low severity issue is not resolved within the resolution period.
+
+### Keep Customer Data Confidential
+<a name='customer-data-confidentiality'></a>
+
+Consider.it LLC agrees not to access, use, or disclose Customer Data without Permission, except:
+
+1.  as needed to host Customer’s Forum
+2.  to monitor use of Customer’s Forum to prevent, detect, and mitigate breach of this agreement
+3.  to respond to Support Requests
+4.  for internal to Consider.it LLC use to aid software development (with anonymized data)
+
+### Provide Downloads of Customer Data
+
+While this agreement continues, and if the Service Plan specifies it, Consider.it LLC agrees to ensure that the Administrator Dashboard provides on-demand downloads of Customer Data.
+
+### Take Security Precautions
+
+Consider.it LLC agrees to take industry-standard security precautions to defend Customer’s Forum from malicious technical attack and Data Compromise. Consider.it LLC does not agree to make sure Customer’s Forum is completely free of software bugs or configuration errors affecting security, or completely secure from all possible technical attacks.
+
+### Prepare for Disasters
+
+While this agreement continues, Consider.it LLC agrees to:
+
+1.  adopt, maintain, and periodically review a written plan to recover from any Disaster affecting the systems used to provide Customer’s Forum or the integrity of Customer Data
+2.  follow the plan if a Disaster happens
+
+### Use Responsible Subcontractors
+
+Consider.it LLC agrees to make sure its employees and contractors abide by [Keep Customer Data Confidential](#customer-data-confidentiality), Take Security Precautions, Prepare for Disasters, and Keep Malicious Code Out of the Software. Consider.it LLC may contract with others to provide computer systems used to provide Customer’s Forum to Customer.
+
+### Keep Malicious Code Out of the Software
+
+While this agreement continues, Consider.it LLC agrees to make sure the Latest Version of Consider.it is free of computer viruses, Trojans, worms, and other malicious code.
+
+### Limit Validation Code in the Software
+
+Consider.it LLC agrees not to include any code that automatically disables Software Features based on monitoring of Use Limits. Consider.it LLC may include code that monitors Use Limits, validates administrative Access Credentials, and reports results back to Consider.it LLC systems.
+
+### Preconfigure Consider.it Features and Limits
+
+Consider.it LLC may preconfigure Consider.it to use services hosted by Consider.it LLC or third parties, such as e-mail and data storage, rather than services of Customer’s choice. Consider.it LLC may also implement hard and soft configuration limits and policies to better reflect the typical operational and security needs of paying customers.
+
+### Protect Customer from Liability
+
+For any Service Plan that includes fees paid by Customer, so long as Customer has paid all Fees as required by this agreement:
+
+#### Indemnify Customer
+<a name="indemnify-customer"></a>
+
+Subject to Indemnification Process, Consider.it LLC agrees to give Customer Indemnification for Legal Claims by others alleging that Permitted Use of Customer’s Forum infringes any copyright, trademark, or trade secret right, or breaks any law.
+
+#### Give Notice of Infringement and Noncompliance Claims
+
+Consider.it LLC agrees to give Customer prompt Notice of any Infringement or Noncompliance Claim.
+
+### Protect Customer After this Agreement Ends
+
+[Keep Customer Data Confidential](#customer-data-confidentiality) and [Indemnify Customer](#indemnify-customer) continue after this agreement ends. Customer can request that Customer's Forum be deleted in entirety at any point. 
+
+### Modifying the Service
+
+We make a promise to our customers to support our Services. That means when it comes to security, privacy, and customer support, we will continue to maintain any legacy Services. Sometimes it becomes technically impossible to continue a feature or we redesign a part of our Services because we think it could be better or we decide to close new signups of a product. We reserve the right at any time to modify or discontinue, temporarily or permanently, any part of our Services with or without notice.
+
+### Modifying the Pricing
+
+Sometimes we change the pricing structure for our products. When we do that, we tend to exempt existing customers from those changes. However, we may choose to change the prices for existing customers. If we do so, we will give at least 30 days notice and will notify you via the email address on record. We may also post a notice about changes on our websites or the affected Services themselves.
+
+### Delete Customer's Forum Data When Agreement Ends
+
+When this agreement ends (usually through written notification from a Customer), we must respond in a timely manner to delete the data on Customer's Forum. 
+
+
+Customer’s Obligations
+----------------------
+
+### Pay Fees
+<a name='pay-fees'></a>
+
+Customer agrees to pay all Fees for Hosting Period, as agreed in the Service Plan. Customer agrees to pay all tax on fees, except tax Consider.it LLC owes on income.
+
+### Follow Rules About Use
+<a name='follow-use-rules'></a>
+
+Customer agrees to [all use restrictions](/docs/legal/use_restrictions). 
+
+#### Configure the Services in compliance with local regulations
+
+Our Services can be configured by Customer to collect certain data from invited users, and to make certain features active (e.g. Google Translate Widget for multi-lingual forums). It is the responsibility of the Customer to make sure their configurations of our Services are compliant with any local laws or regulations. Please contact us at [help@consider.it](mailto:help@consider.it) if you have any concerns about how your configurations are aligned with local regulations. 
+
+#### Data Processing Addendum for GDPR compliance 
+
+These Service Terms incorporate the [Consider.it Data Processing Addendum](/docs/legal/data_processing_addendum) (“DPA”), when the General Data Protection regulation (“GDPR”) applies to your use of Consider.it to process Personal Data. If you prefer to have an executed copy of the DPA, contact us at [help@consider.it](mailto:help@consider.it) to request a signed DPA. Regardless of whether you execute or not, we protect and secure your data to the high standards set out in the addendum.
+
+#### California Consumer Privacy Act (“CCPA”)
+
+Under the California Consumer Privacy Act (“CCPA”), Consider.it is a “service provider”, not a “business” or “third party”, with respect to your use of the Services. That means we process any data you share with us only for the purpose you signed up for and as described in these Terms of Service, [Privacy policy](/docs/legal/privacy_policy), and other policies. We do not retain, use, disclose, or sell any of that information for any other commercial purposes unless we have your explicit permission. And on the other hand, you agree to comply with your requirements under the CCPA and not use our Services in a way that violates the regulations.
+
+
+### Enforce Rules About Use
+<a name="enforce-use-rules"></a>
+
+Customer agrees to make sure Customer Personnel abide by [Follow Rules About Use](#follow-use-rules).
+
+### Update Account Details
+
+While this agreement continues, Customer agrees to keep its contact, payment, and other administrative details complete, accurate, and up-to-date. Customer agrees to do so through the Administrator Dashboard whenever possible, and otherwise by Notice.
+
+### Choose Public Terms and Policies
+
+Customer agrees to review provided template terms of service and privacy policies, and to replace, adapt, or withdraw their terms to suit Customer’s interests and comply with the law. While this agreement continues, Consider.it LLC agrees to respond to questions about how Consider.it LLC provides Customer’s Forum that are relevant to compliance as Support Requests.
+
+### Respond to Support Follow-Ups
+
+Customer agrees to make sure that relevant Customer Personnel respond quickly to follow-up questions about Support Requests.
+
+
+### Notify us when this agreement should be terminated
+
+We continue to retain Customer data and Content provided by invited users to Customer's Forum until Customer gives written notice to terminate this agreement, unless Customer's Forum is terminated earlier for some other reason. It is your responsibility to notify us if and when you want Customer's Forum to be taken down in order to comply with any laws (e.g. Special Data Regulations) or organizational policies that may apply. 
+
+
+### Indemnify Consider.it LLC
+<a name="indemnify-us"></a>
+
+Subject to Indemnification Process, Customer agrees to give Consider.it LLC Indemnification from Legal Claims by others based on:
+
+1.  Customer’s breach of this agreement
+2.  Customer Data
+3.  Use of Customer’s Forum at Customer’s Own Risk
+4.  Misuse of Customer’s Access Credentials
+
+### Protect Consider.it LLC After this Agreement Ends
+
+[Pay Fees](#pay-fees) and [Indemnify Consider.it LLC](#indemnify-us) continue after this agreement ends.
+
+Intellectual Property
+---------------------
+
+### Existing and Outside IP
+
+This agreement does not change ownership of any Intellectual Property Right held by either side before entering this agreement, or created during the term of this agreement. Any Intellectual Property created in the course of this agreement by Consider.it LLC remains its property unless agreed to specifically in a contract.
+
+### Open Source Licenses
+
+Customer’s licenses for Consider.it are those of their respective open source licenses, interpreted as entirely independent legal documents, separate from these terms. Obligations and guarantees about Consider.it are in these terms, such as in Consider.it LLC’s Obligations, are in addition to the terms of those standard open source licenses.
+
+### Hosting Tools
+
+Consider.it LLC develops and uses Hosting Tools in the form of software and software configurations for setting up, hosting, monitoring, and upgrading Consider.it for multiple customers on a variety of infrastructure platforms. This agreement does not change ownership of any Intellectual Property Right in Hosting Tools held by Consider.it LLC before entering this agreement, or created during the term of this agreement.
+
+Changes
+-------
+
+### Changes Customer May Make
+
+1.  Customer may end this agreement at any time by giving Notice.
+2.  Customer may update its address for Notice under Notice Process.
+
+### Changes Consider.it LLC May Make
+
+1.  Consider.it LLC may end this agreement at any time by giving Notice at least six months in advance.
+2.  Consider.it LLC may end this agreement immediately for any free forum, without Notice.
+3.  Consider.it LLC may end this agreement immediately if Customer breaches this agreement, by giving Notice.
+4.  Consider.it LLC may add, remove, and change Software Features in the Latest Version of Consider.it.
+5.  Consider.it LLC may add, remove, and change the functionality of the Administrator Dashboard.
+6.  Consider.it LLC may take any of these steps in response to an Infringement or Noncompliance Claim:
+    1.  Consider.it LLC may release a new Latest Version of Consider.it so that use of Customer’s Forum as provided will no longer infringe or break the law.
+    2.  Consider.it LLC may change how it provides Customer’s Forum so that use of Customer’s Forum as provided will no longer infringe or break the law.
+    3.  If the problem is infringement, Consider.it LLC may get a license for Customer so that use of Customer’s Forum will no longer infringe.
+    4.  If the problem is illegality, Consider.it LLC may get the government approvals, licenses, or other requirements needed to abide by the law.
+    5.  Consider.it LLC may end this agreement and refund any Prepaid Fees.
+    6.  Consider.it LLC may update its address for Notice under Notice Process.
+
+Liability
+---------
+<a name="liability"></a>
+
+### Agreed Legal Remedies
+
+1.  Each side’s only legal remedy for Legal Claims covered by Indemnification will be Indemnification.
+2.  Customer’s only legal remedies for failures to meet Service-Level Agreement will be refunds under Remedies.
+
+### Valid Excuses
+
+Neither side will be liable for any failure or delay in meeting any service level or other obligation under this agreement caused by a Disaster, failure of the other side or its personnel to meet their obligations under this agreement, or actions done or delayed on written request of the other side.
+
+### Only Express Warranties
+
+Except for its obligations in [Consider.it LLC’s Obligations](#considerit-obligations), Consider.it LLC provides Customer’s Forum “as is”, without any warranty at all. Consider.it LLC disclaims any warranties the law might otherwise imply, like warranties of merchantability, fitness for any particular purpose, title, or noninfringement.
+
+### Limited Damages
+
+#### Damages Cap
+
+Subject to Damages Limit Exceptions, neither side’s total liability for breach of this agreement will exceed the amount of Fees Consider.it LLC received from Customer during the twelve months before the first claim is filed. This limit applies even if the side liable is advised that the other may suffer damages, and even if Customer paid no fees at all.
+
+#### No Unforeseeable Damages
+
+Neither side will be liable for breach-of-contract damages they could not have reasonably foreseen when entering into this agreement.
+
+#### Damages Limit Exceptions
+
+Limited Damages does not limit damages for breach of:
+
+1.  [Pay Fees](#pay-fees)
+2.  [Keep Customer Data Confidential](#customer-data-confidentiality)
+3.  [Follow Rules About Use](#follow-use-rules)
+4.  [Enforce Rules About Use](#enforce-use-rules)
+5.  [Indemnify Customer](#indemnify-customer)
+6.  [Indemnify Consider.it LLC](#indemnify-us)
+
+Process
+-------
+
+### Indemnification Process
+
+Both sides agree that to receive Indemnification under this agreement, they must give Notice of any covered Legal Claims quickly, allow the other side to control investigation, defense, and settlement, and cooperate with those efforts. Both sides agree that if they fail to give Notice of any covered Legal Claims quickly, Indemnification will not cover amounts that could have been defended against or mitigated if Notice had been given quickly. Both sides agree that if they take control of the defense and settlement of any Legal Claims covered by Indemnification, they will not agree to any settlements that admit fault or impose obligations on the other side without their Permission.
+
+### Notice Process
+
+Both sides agree that to give Notice under this agreement, the side giving Notice must send by e-mail to the address the recipient gave with its signature, or to a different address given later for Notice going forward. If either side finds that e-mail can’t be delivered to the e-mail address given, it may give Notice by registered mail to the address on file for the recipient with the state under whose laws it is organized.
+
+General Contract Terms
+----------------------
+
+### Governing Law
+
+The law of the state of Oregon in the United States will govern this agreement.
+
+### Government Procurement
+
+Consider.it is commercial computer software. If Customer’s procurement is subject to Federal Acquisition Regulation 12.212 or Defense Federal Acquisition Regulation Supplement 227.7202, Customer’s rights will be only those stated in this agreement.
+
+### Whole Agreement
+
+Both sides intend these Consider.it Forum Hosting Terms, the [Terms of Service](/docs/legal/terms_of_service), the [Data Processing Addendum](/docs/legal/data_processing_addendum) (if applicable), the Service Plan of the respective plan described at [https://consider.it](https://consider.it/pricing), and any additional contract signed by both parties as the final, complete, and only expression of their terms about use of Customer’s Forum and related support services. However, this agreement does not affect the terms of any separate nondisclosure or confidentiality agreement Consider.it LLC and Customer may have.
+
+### Enforcement
+
+Only Consider.it LLC and Customer may enforce this agreement.
+
+### Assignment
+
+Each side may assign all its rights, licenses, and obligations under this agreement, as a whole, to a new legal entity created to change its jurisdiction or legal form of organization, or to an entity that acquires substantially all of its assets or enough securities to control its management. Otherwise, each side needs Permission to assign any right or license under this agreement. Attempts to assign against these terms will have no legal effect.
+
+### Lawsuits
+
+#### Forum
+
+Both sides agree to bring any Lawsuit in Multnomah County Courts.
+
+#### Exclusive Jurisdiction
+
+Both sides consent to the exclusive jurisdiction of Multnomah County Courts. Both sides may enforce judgments from Multnomah County Courts in other jurisdictions.
+
+#### Inconvenient Forum Waiver
+
+Both sides waive any objection to venue for any Lawsuit in Multnomah County Courts and any claim that the other brought any Lawsuit in Multnomah County Courts in an inconvenient forum.
+
+
+Changes
+-------
+
+We will change this policy from time to time. When we do, we will revise the date at the top of the policy. As of January 2023, our legal policies will be available [on GitHub](https://github.com/Considerit/ConsiderIt/tree/master/public/docs), where you can review all changes that have been made over time. We encourage you to review this policy whenever you access or use our Services or otherwise interact with us. If you continue to use our Services after changes go into effect, you consent to the revised policy.
+
+Definitions
+-----------
+
+1.  Access Credentials means a user name and password, license key, or other secret that affords use of Customer’s Forum or systems providing Customer’s Forum.
+2.  Administrator Dashboard means the pages of Customer’s Forum accessible only to Forum Hosts.
+3.  Customer Data means data that:
+    1.  Users furnish to Customer’s Forum, such as by entering it or configuring Customer’s Forum to gather or receive it, if doing so doesn’t breach this agreement
+    2.  Customer’s Forum collects about Users and how they use Customer’s Forum
+4.  Customer Personnel means Customer’s employees and each Customer subsidiary’s employees, as well as independent contractors providing services to Customer.
+5.  Data Compromise means malicious technical compromise or unauthorized disclosure of Customer Data.
+6.  Disaster means:
+    1.  fire, flood, earthquake, pandemic, and other natural disasters
+    2.  declared and undeclared wars, acts of terrorism, sabotage, riots, civil disorders, rebellions, and revolutions
+    3.  extraordinary malfunction of Internet infrastructure, data centers, or communications utilities
+    4.  malicious technical attack on systems providing Customer’s Forum
+    5.  government actions taken in response to any of these causes
+7.  Feature Set means all Software Features of the selected Consider.it plan described at [https://consider.it](https://consider.it) on the date the respective forum was created or payment made, whichever is later.
+8.  Fees means all fees agreed in the Service Plan.
+9.  Forum Activity is any action taken by Users in Customer's Forum to add a new opinion or comment, as demonstrated at [https://consider.it](https://consider.it).
+10.  Hosting Period is the time during which Consider.it LLC agrees to provide the Hosting Services to Customer. The Hosting Period starts on the date of this agreement, unless otherwise stipulated. The Hosting Period ends when Customer's Forum receives no new Forum Activity for a period of at least six months, unless otherwise stipulated. While the hosting period may be over, we do not automatically remove your forum, and may continue to host the forum indefinitely, unless we receive written communication from you to remove the forum and its contents. The plural is Hosting Periods.
+11.  Hosting Services means the work needed to host Customer’s Consider.it forum so that Users can use the Feature Set by visiting Customer’s Forum.
+12.  Indemnification means indemnifying and holding harmless for all liability, expenses, damages, and costs.
+13.  Infringement or Noncompliance Claim means a court order against use of Consider.it based on a claim that it infringes any Intellectual Property Right, or breaks any law, or a threat of that kind of claim that Consider.it LLC believes credible.
+14.  Intellectual Property Right means any patent, copyright, trademark, or trade secret right, or any other legal right typically referred to as an intellectual property right.
+15.  Lapsed Forum is a Consider.it forum that received no new Forum Activity for a period of at least six months during its Hosting Period, even if it subsequently received new Forum Activity.
+16.  Latest Version of Consider.it means the most recent version of Consider.it that Consider.it LLC uses in production, rather than test or development, systems.
+17.  Lawsuit means a lawsuit brought by one side against the other, related to this agreement or Customer’s Forum.
+18.  Legal Claims means claims, demands, lawsuits, and other legal actions.
+19.  Notice means a written communication from one side to the other per Notice Process.
+20.  Permission means prior Notice of consent.
+21.  Permitted Use of Customer’s Forum means Customer’s use of Customer’s Forum, other than Use of Customer’s Forum at Customer’s Own Risk.
+22.  Prepaid Fees means Fees Customer prepaid for a Hosting Period yet to begin.
+23.  Multnomah County Courts means the Oregon state courts sitting in Multnomah County or the United States District Court for the District of Oregon.
+24.  Service Plan means the Hosting Services and any additional scope of work the parties agree to via contract.
+25.  Software Features means functions of Consider.it described at [https://consider.it](https://consider.it).
+26.  Special Data Regulations means laws and regulations that impose special requirements on the collection, storage, processing, or transmission of particular sensitive kinds of data about individuals. The Gramm-Leach-Bliley Act, Health Insurance Portability and Accountability Act, Children’s Online Privacy Protection Act, Fair Credit Reporting Act, and European Union General Data Protection Regulation rules about special categories of personal data are some Special Data Regulations. Laws that apply to data just because they may identify specific individuals, such as GDPR rules about personal data more broadly and the California Consumer Privacy Act, are not Special Data Regulations.
+27.  Use of Customer’s Forum at Customer’s Own Risk means:
+    1.  use of Customer’s Forum in breach of this agreement
+    2.  use of Customer’s Forum with changes, additions, or in combination with other software, systems, or data, in a way that infringes someone else’s Intellectual Property Right or breaks the law, if use of Customer’s Forum as provided, as described by the Documentation, would not
+    3.  unauthorized use of Customer’s Forum with Customer Access Credentials
+28.  Uptime means the percentage of wall-clock time during a Hosting Period when Users can read and post to a Customer’s Forum, subject to Valid Excuses.
+29.  Use Limits means numeric limits on technical aspects of Customer’s Forum, such as amount of data storage space.
+30.  Users means users of Customer’s Forum, both Customer Personnel and others.

--- a/public/docs/subprocessors.md
+++ b/public/docs/subprocessors.md
@@ -1,0 +1,44 @@
+Consider.it Processors
+=======================
+Updated: February 2023
+
+Subprocessors 
+-------------
+
+We use third party subprocessors, such as cloud computing providers and customer support software, to run Consider.it (the service). We have tried to minimize the number of these processors. And when we do use a subprocessor, we try to ensure each subprocessor has a GDPR-compliant data processing agreement. And if they don't, we provide an option for the respective forum host in charge of controlling how Consider.it processes data to disable processing by that subprocessor (e.g. Google Translate).
+
+The following is a list of personal data subprocessors we use.
+
+*   [Linode](https://www.linode.com/legal/) - Cloud computing services. Linode hosts our US, EU, and Canadian servers.
+*   [Amazon Web Services](https://aws.amazon.com/compliance/gdpr-center/) - Cloud computing services. The [AWS service terms](https://aws.amazon.com/service-terms/) for all AWS systems incorporates a GDPR compliant DPA.
+    * [Cloudfront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/data-protection-summary.html)
+    * [S3](https://d1.awsstatic.com/legal/aws-dpa/aws-dpa.pdf)
+    * [SES](https://docs.aws.amazon.com/ses/latest/dg/data-protection.html) - Transactional email service. Most machine-generated Consider.it emails are sent via SES.
+*   [Mailgun](https://www.mailgun.com/gdpr/) - Some machine-generated Consider.it emails are sent via Mailgun.
+*   [Plausible](https://plausible.io/data-policy) - Privacy-first analytics service. Based in the EU.
+*   Google Translate - Language Translation. Can be turned off entirely for a given forum.
+*   [Stripe](https://stripe.com/legal/dpa) - Billing. Stripe is only loaded for a Customer trying to pay for a premium forum.
+
+
+
+
+For our US server, AWS and Linode services are hosted on servers in the US. 
+
+The EU has strong privacy laws. A core tenet of the GDPR is that if we transfer any personal data of EU residents out of the EU, we must protect it to the same level as guaranteed under EU law. We try to minimize the amount of cross-border data transfer. For our European server, AWS and Linode services are hosted on servers in the EU. Plausible is also based in the EU. We use an EU-based Mailgun server for our Consider.it EU server. Google Translate is disabled by default on the EU server. 
+
+For our Canadian server, AWS and Linode services are hosted on servers in Canada. 
+
+
+Company Processors
+------------------
+
+As a company, we use third-party software that may process your information under certain circumstances.
+
+*   [Google Suite](https://cloud.google.com/security/gdpr). Our @consider.it emails are provided through Google Suite.
+
+Furthermore, we use social media. If you voluntarily engage with us through those media, your personal information may also be collected by the following processors:
+
+*   [LinkedIn](https://privacy.linkedin.com/gdpr). Professional networking platform.
+*   [Zoom](https://zoom.us/gdpr). Video conferencing platform.
+*   [Twitter](https://gdpr.twitter.com/). Social media platform.
+*   [Facebook](https://www.facebook.com/business/gdpr). Social media platform.

--- a/public/docs/terms_of_service.md
+++ b/public/docs/terms_of_service.md
@@ -1,0 +1,197 @@
+Consider.it Terms of Service
+============================
+
+Updated: February 2023
+
+Thanks for using Consider.it! These Terms of Service help us clarify our relationship, in the form of a legal contract between you (the "User" of the Service) and us (Consider.it LLC) when you access a Consider.it forum and/or sign up to use a Consider.it service.
+
+When we say "Consider.it", "Company", "we", or "us" in this document, we mean Consider.it LLC. Consider.it LLC is the company that develops Consider.it, a computer software platform for running Internet deliberation forums. 
+
+We have established the Consider.it website located at [https://consider.it](https://consider.it) and any of its subdomains, which we collectively call the “Site”. Each subdomain of Consider.it is a separate “Forum” that enables you to provide input, feedback and suggestions on the topics described on pages of the Site and contribute to the conversation with other users of the Site, as applicable. 
+
+When we say "Services", we are collectively referring to the Site and the services we provide.
+
+When we say “You” or “your” or "User", we are referring to the people or organizations that own an account with one or more of our Services.
+
+When we say the “Forum Host” or “the Host”, we are referring to the person or persons who created and/or administer a specific Consider.it forum. The Forum Host may or may not represent an organization and, with few exceptions, is not affiliated with us.
+
+We may update these Terms of Service in the future. You can track changes [on GitHub](https://github.com/Considerit/ConsiderIt/tree/master/public/docs). However, our pledge to never sell your data to third parties will remain in place. 
+
+When you use our Services, now or in the future, you are agreeing to the latest Terms of Service. Please read these Terms carefully because they govern your use of the Site and our services. There may be times where we do not exercise or enforce any right or provision of the Terms of Service; in doing so, we are not waiving that right or provision. **These terms do contain a limitation of our liability.**
+
+If you do not agree to this agreement, you should not use our Services. 
+
+Please also take a look at Consider.it’s [Privacy Policy](/docs/legal/privacy_policy). The Privacy Policy explains how we collect and use your information. 
+
+For Forum Hosts, and if applicable, the organization(s) on behalf of whom the forum is hosted, these terms also incorporate the [Consider.it Forum Hosting Terms](/docs/legal/standard_hosting_terms).
+
+
+Acceptance of Terms
+-------------------
+
+By using our Services in any way, including registering on the Site, contributing your input, feedback or suggestions, or browsing the Site, you agree to be and are bound by these Terms. If you do not agree to all of the Terms, do not access or use our Services.
+
+
+Who can use Consider.it?
+------------------------
+
+You may use our Services only if you can form a binding contract with Consider.it, and only in compliance with these Terms and all applicable laws. 
+
+### Age
+
+Any use or access by anyone under the age of 13 is prohibited.
+
+### Organization representation
+
+If you open an account on behalf of a company, organizations, or other entity, then (a) “you” includes you and that entity, and (b) you represent and warrant that you are authorized to grant all permissions and licenses provided in these Terms and bind the entity to these Terms, and that you agree to these Terms on the entity’s behalf.
+
+
+Account Responsibilities
+------------------------
+
+1.  You are responsible for maintaining the security of your account and password. You must immediately notify us of any unauthorized uses of your account, or any other breaches of security. We cannot and will not be liable for any loss or damage from your failure to comply with this security obligation.
+2.  You may not use the Services for any purpose outlined in our [Use Restrictions policy](/docs/legal/use_restrictions). You must not, in the use of the Service, violate any laws in your jurisdiction (including but not limited to copyright or trademark laws). The Use Restrictions Policy is part of our Terms of Service.
+3.  You are responsible for all content posted and activity that occurs under your account. That includes content posted by others who either: (a) have access to your login credentials; or (b) have their own logins under your account.
+4.  You must be a human. Accounts registered by “bots” or other automated methods are not permitted.
+5.  You agree not to reproduce, duplicate, copy, sell, resell or exploit any portion of the Services, use of the Services, or access to the Services without our express written permission.
+6.  You must not modify another website so as to falsely imply that it is associated with the Services or Consider.it LLC.
+
+
+Reliance on Information Posted
+------------------------------
+
+The information presented on or through the Services is made available solely for general information purposes. This includes the proposals, points, comments, photos, links and other materials Consider.it allows users to post (Anything that a user posts or otherwise makes available on our Services is referred to as “Content").
+
+We do not warrant the accuracy, completeness or usefulness of this information. Any reliance you place on such information is strictly at your own risk. We disclaim all liability and responsibility arising from any reliance placed on such materials by you or any other visitor to Consider.it, or by anyone who may be informed of any of its contents. You understand that by using the Site you may be exposed to Content that is offensive, indecent or objectionable.
+
+The Services may provide, or third parties may provide, links to other websites or resources. Because Consider.it has no control over such sites and resources, you acknowledge and agree that Consider.it is not responsible for the availability of such external sites or resources, and does not endorse and is not responsible or liable for any content, advertising, products or other materials on or available from such sites or resources. You further acknowledge and agree that Consider.it shall not be responsible or liable, directly or indirectly, for any damage or loss caused or alleged to be caused by or in connection with use of or reliance on any such content, goods or services available on or through any such site or resource.
+
+
+
+Your Content
+---------------------------------
+
+### You own your content on Consider.it
+
+You own all of the Content you post on Consider.it and retain all rights therein. We claim no intellectual property rights over the material you provide to the Services. All materials uploaded remain yours.
+
+#### Limited license grant to Consider.it LLC
+When you use our Services, you give Consider.it LLC a perpetual, worldwide, irrevocable, non-exclusive, royalty-free license to use, host, store, reproduce, create derivative works (such as those resulting from language translations, adaptations or other changes we make so that your Content works better with our Services), communicate, publish, display, and distribute such Content. This license continues even if you stop using our Services.
+
+### You are responsible for your content
+
+When you post or otherwise submit Content to the Site, you acknowledge and agree that you, and not Consider.it, are entirely responsible for all such Content. You agree to defend, indemnify and hold harmless Consider.it, its affiliates, licensors and service providers, and its and their respective officers, directors, employees, contractors, agents, licensors, suppliers, successors and assigns from and against any claims, liabilities, damages, judgments, awards, losses, costs, expenses or fees (including reasonable attorneys' fees) arising out of or relating to your violation of these Terms of Use or your use of the Site, including, but not limited to, your Content, any use of the Site’s content, services and products other than as expressly authorized in these Terms of Use or your use of any information obtained from the Site. By making Content available, you represent and warrant that:
+1.  The downloading, copying and use of the Content will not infringe the proprietary rights, including but not limited to the copyright, patent, trademark or trade secret rights, of any third party;
+2.  If your employer has rights to intellectual property you create, you have either (i) received permission from your employer to post or make available the Content, including but not limited to any software, or (ii) secured from your employer a waiver as to all rights in or to the Content;
+3.  You have fully complied with any third-party licenses relating to the Content, and have done all things necessary to successfully pass through to end users any required terms;
+4.  The Content does not contain or install any viruses, worms, malware, Trojan horses or other harmful or destructive content;
+5.  The Content is not spam, is not machine-generated (unless otherwise approved), is not randomly-generated, and does not contain unethical or unwanted commercial content designed to drive traffic to third party sites or boost the search engine rankings of third party sites, or to further unlawful acts (such as phishing) or mislead recipients as to the source of the material (such as spoofing);
+6.  The Content is not pornographic, does not contain threats or incite violence, and does not violate the privacy or publicity rights of any third party;
+
+### Data Requests
+
+You may request data related to your personal account. We will take reasonable efforts to provide this data. Consider.it has the right to refuse repetitive or technically difficult requests. For information about how we collect and share user information, please refer to Consider.it’s [privacy policy](/docs/legal/privacy_policy).
+
+### Data retention
+
+We continue to retain data that you provide to a forum until the Forum Host terminates their agreement with us, or until you [delete your account or delete your data for a particular forum](/docs/legal/deleting_your_data).
+
+
+Copyright Infringement
+----------------------
+
+If you believe that any content or user contributions violate your copyright, please email us at [hello@consider.it](mailto:hello@consider.it) for instructions on sending us a notice of copyright infringement. It is the policy of the Consider.it to terminate the user accounts of repeat infringers.
+
+Note that the names, look, and feel of the Services are copyright© to the Company. All rights reserved. You must request permission to use the Company's logo or any Service logos for promotional purposes. Please [contact us](https://consider.it/contact) for requests to use logos. We reserve the right to rescind this permission if you violate these Terms of Service.
+
+
+
+Security and Privacy
+--------------------
+
+1.  Your use of the Services is at your sole risk. 
+2.  We reserve the right to temporarily disable your account if your usage significantly exceeds the average usage of other customers of the Services such that your usage is negatively impact the performance of the Service for other customers. This is so rare that it has yet to happen.
+3.  We use industry standard practices to protect and secure your data through backups, redundancies, and encryption. We enforce encryption for data transmission from the public Internet. There are some edge cases where we may send your data through our network unencrypted.
+4.  You agree that we may process your data as described in our [Privacy Policy](/docs/legal/privacy_policy) and for no other purpose. We as humans can access your data for the following reasons:
+    * _To help with support requests you make or a forum host makes._ If you contact us with a support inquiry, we may need to access your account to help resolve a problem. Similarly, if there is a problem at the forum level, in our investigation we may have to access your account.
+    * _After fixing a bug that affected you_. Our server can recognize some types of software errors, and automatically notify us when they occur. Sometimes the information included in these automated error reports reveal a bug that, through investigation, we can figure out that it has impacted you. In those rare cases, we may choose to personally (and sheepishly) reach out to you after we fix the problem, so that you can take restorative action. 
+    * _To safeguard Consider.it._ We'll look at logs and metadata as part of our work to ensure the security of your data and the Services as a whole. If necessary, we may also access accounts as part of an [abuse investigation](/docs/legal/use_restrictions).
+    * _As shared with your forum host_. Consider.it helps the person and/or organization who started the Consider.it forum facilitate a dialogue. Paid versions of Consider.it enable data export of forum data to the forum hosts, including your username and email address.
+    * _To the extent required by applicable law._ We only preserve or share customer data if compelled by a US government authority with a legally binding order or proper request under the Stored Communications Act. If a non-US authority approaches us for assistance, our default stance is to refuse unless the order has been approved by the US government, which compels us to comply through procedures outlined in an established mutual legal assistance treaty or agreement mechanism. If we are audited by a tax authority, we only share the bare minimum billing information needed to complete the audit.
+5.  We use third party vendors and hosting partners to provide the necessary hardware, software, networking, storage, and related technology required to run the Services. You can see a list of [all our subprocessors](/docs/legal/subprocessors) who handle personal data.
+6.  You may request data related to your personal account and service. We have the right to refuse repetitive or technically difficult requests. For information about how we collect and share user information please refer to our [Privacy Policy](/docs/legal/privacy_policy).
+
+
+
+Features and Bugs
+-----------------
+
+We take pride in the Services we have created, and we love to incorporate into our designs the feedback of users and customers who take the time to give it. But our Service won't match everyone's needs. Consider.it is a tool, and not every project needs a tool of Consider.it's particular shape. We therefore make no guarantee that our Services will meet your specific requirements or expectations.
+
+Furthermore, errors in the software are inevitable, no matter how diligently we test the system before we deploy changes. We do our best to quickly address major bugs (and redress whatever harm we can). We track all bugs reported to us. And we thank you for your understanding.
+
+
+Termination
+-----------
+
+If you wish to terminate your Consider.it account, you can just discontinue using the Services. Or you may [delete your account](/docs/legal/deleting_your_data). All provisions of the Terms which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.
+
+
+### Considerit-initiated terminations
+We have the right to suspend or terminate your account and refuse any and all current or future use of our Services for any reason at any time. Termination will furthermore result in the deletion of your account or your access to your account, and the forfeiture and relinquishment of all content in your account. If you are an administrator of one or more forums, those forums may also be entirely suspended or deleted. We also reserve the right to refuse the use of the Services to anyone for any reason at any time. We include this clause because of the one in a million account holder who is doing something malicious. In practice, this generally means we will cancel your account without notice if we have evidence that you are using our products to engage in [abusive behavior](/docs/legal/use_restrictions). Verbal, physical, written or other abuse (including threats of abuse or retribution) of Company employee or officer will result in immediate account termination.
+
+
+
+
+
+
+
+
+Use of site by Governmental Entities
+------------------------------------
+
+Consider.it intends to comply with all local, state and federal laws related to the required disclosure of any information provided via the Services. Under some instances the entity sponsoring specific Content or a project (“Host”) through our Services will be a governmental entity. In such instances, the governmental Host may or may not use the information that you provide to the Services for the purposes associated with the Services. It should be noted that such information may or may not be considered public information or public records under applicable state and federal laws. To the extent that anything you contribute to the Services, including your personal information, is considered a public record or as otherwise belonging to a governmental entity and, therefore, subject to certain local, state or federal disclosure laws, such applicable laws will govern the use and required disclosure of such information.
+
+
+
+
+
+Limitation of Liability
+-----------------------
+
+This section is important as it outlines liability terms between us and users of the Services. For Forum Hosts of a Consider.it forum using Consider.it's Hosting Services, the [Liability section of the Forum Hosting Terms](/docs/legal/standard_hosting_terms#liability) supercedes the following Limitation of Liablity clauses if there is a conflict.
+
+In no event shall Consider.it, its affiliates or their respective officers, directors, members, managers, partners, employees, or agents (or the Forum Host) be liable to you or any third party for any special, punitive, incidental, indirect or consequential damages or losses of any kind, or any damages or losses whatsoever, including those resulting from loss of use, data or profits, whether or not foreseeable or if Consider.it (or the Forum Host) has been advised of the possibility of such damages or losses, and on any theory of liability, including breach of contract or warranty, negligence or other tortious action, or any other claim arising out of or in connection with: (i) the access or use or of or the inability to access or use the services; (ii) the statements or actions of any third party on or via the services; (iii) any dealings with vendors or other third parties; (iv) any unauthorized access to or alteration of your transmissions, submitted content or other data; (v) any information that is sent or received or not sent or received; (vi) any failure to store or loss of data, files, materials or other content; (vii) any services available that are delayed or interrupted; (viii) any web site referenced or linked to from this services; or ix) your access to or use of or inability to access or use any linked site. Some jurisdictions prohibit the exclusion or limitation of liability for consequential or incidental damages. Accordingly, the limitations and exclusions set forth above may not apply to you.
+
+You understand that we cannot and do not guarantee or warrant that files available for downloading from the internet or the Site will be free of viruses or other destructive code. You are responsible for implementing sufficient procedures and checkpoints to satisfy your particular requirements for anti-virus protection and accuracy of data input and output, and for maintaining a means external to our site for any reconstruction of any lost data. WE WILL NOT BE LIABLE FOR ANY LOSS OR DAMAGE CAUSED BY A DISTRIBUTED DENIAL-OF-SERVICE ATTACK, VIRUSES OR OTHER TECHNOLOGICALLY HARMFUL MATERIAL THAT MAY INFECT YOUR COMPUTER EQUIPMENT, COMPUTER PROGRAMS, DATA OR OTHER PROPRIETARY MATERIAL DUE TO YOUR USE OF THE SITE OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE SITE OR TO YOUR DOWNLOADING OF ANY MATERIAL POSTED ON IT, OR ON ANY WEBSITE LINKED TO IT.
+
+YOUR USE OF THE SITE, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE SITE IS AT YOUR OWN RISK. THE SITE, ITS CONTENT AND ANY SERVICES OR ITEMS OBTAINED THROUGH THE WEBSITE ARE PROVIDED ON AN "AS IS" AND "AS AVAILABLE" BASIS, WITHOUT ANY WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. NEITHER CONSIDER.IT NOR ANY PERSON ASSOCIATED WITH CONSIDER.IT MAKES ANY WARRANTY OR REPRESENTATION WITH RESPECT TO THE COMPLETENESS, SECURITY, RELIABILITY, QUALITY, ACCURACY OR AVAILABILITY OF THE SITE. WITHOUT LIMITING THE FOREGOING, NEITHER CONSIDER.IT NOR ANYONE ASSOCIATED WITH CONSIDER.IT REPRESENTS OR WARRANTS THAT THE SITE, ITS CONTENT OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE SITE OR SERVICES WILL BE ACCURATE, RELIABLE, ERROR-FREE OR UNINTERRUPTED, THAT DEFECTS WILL BE CORRECTED, THAT OUR SITE OR THE SERVER THAT MAKES IT AVAILABLE ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS OR THAT THE SITE OR ANY SERVICES OR ITEMS OBTAINED THROUGH THE SITE WILL OTHERWISE MEET YOUR NEEDS OR EXPECTATIONS.
+
+CONSIDER.IT HEREBY DISCLAIMS ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, STATUTORY OR OTHERWISE, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT AND FITNESS FOR PARTICULAR PURPOSE.
+
+THE FOREGOING DOES NOT AFFECT ANY WARRANTIES WHICH CANNOT BE EXCLUDED OR LIMITED UNDER APPLICABLE LAW.
+
+
+Indemnity
+---------
+
+For Sponsors of a Consider.it forum using Consider.it's Hosting Services, Indemnification clauses in the [Forum Hosting Terms](/docs/legal/standard_hosting_terms) supercedes the following Indemnity clause if there is a conflict.
+
+You indemnify us against all losses, costs (including legal costs), expenses, demands or liability that we incur arising out of, or in connection with, a third-party claim against us relating to your use of our services or any third-party product (except as far as we’re at fault). 
+
+Applicable law
+--------------
+
+The relationship we have with you under these terms is governed by U.S. law.
+
+
+Change to Terms or Services
+---------------------------
+
+
+We may update these Terms of Service in the future. As of February 2023, you can track any changes to our legal policies [on GitHub](https://github.com/Considerit/ConsiderIt/tree/master/public/docs). These changes are usually just for clarity. Your continued access or use for the Services constitutes your acceptance of the changes. Your access to and use of the Site will be subject to the most current version of the Terms posted on the Site at the time of such use. Please regularly check the [Terms of Service link](/docs/legal/terms_of_service) to view the then-current terms. If you don’t agree to be bound by the modified Terms, then you may no longer use the Services. If you breach any of the Terms, your authorization to access or use our Services automatically terminates. Because our Services are evolving over time we may change or discontinue all or any part of the Services, at any time and without notice, at our sole discretion.
+
+Contact Information
+-------------------
+
+If you have any questions about these Terms or the Services, please contact us at [hello@consider.it](mailto:hello@consider.it).

--- a/public/docs/use_restrictions.md
+++ b/public/docs/use_restrictions.md
@@ -1,0 +1,50 @@
+Use restrictions as a User of a Consider.it forum
+==================================================================
+Updated: February 2023
+
+As a condition of use, you promise not to use the Services for any purpose that is unlawful or prohibited by these Terms, or any other purpose not reasonably intended by Consider.it. Such Content may be subject to removal by Consider.it. By way of example, and not as a limitation, you agree not to use the Services:
+
+*   To abuse, harass, threaten, impersonate or intimidate any person, including sharing other peoples’ private personal information in a context that might lead to harassment;
+*   To share links to or files containing malware or spyware; 
+*   To engage in shady communication that may be indicative of an attempt to defraud others, such as with phishing. 
+*   To post or transmit, or cause to be posted or transmitted, any Content or communications that are libelous, defamatory, abusive, or that infringes any copyright or other right of any person;
+*   For any purpose that is not permitted under the laws of the jurisdiction where you use the Services;
+*   To post or transmit, or cause to be posted or transmitted, any communication designed or intended to obtain password, account, or private information from any other Consider.it user;
+*   To advertise to or solicit, any user to buy or sell any third party products or services, or to use any information obtained from the Services in order to contact, advertise to, solicit, or sell to any user without their prior explicit consent;
+*   To create multiple accounts for the purpose of manipulating the feedback in Consider.it; or
+*   To post copyrighted communications that do not belong to you.
+*   To strain the technical infrastructure of the Forum with an unreasonable volume or rate of requests, or requests designed to impose an unreasonable load
+
+Certain Consider.it sites have a moderation interface and the administrators of those conversations can choose to hide or remove user Content that do not meet the standards of their forum. 
+
+For conversations without moderation, you are responsible for your interactions with other users of the Services. 
+
+To report suspected abuse of the Services or a breach of the Terms please send written notice to Consider.it at email: [hello@consider.it](mailto:hello@consider.it). 
+
+Consider.it reserves the right, but has no obligation, to monitor disputes between you and other users. And while we do not pre-screen content, we reserve the right, but have no obligation, in our sole discretion to refuse or remove any content that is available via the Service.
+
+
+<a name="additional-restrictions-for-hosts"></a>
+
+Additional use restrictions for Forum Hosts
+===========================================
+
+
+As a condition of use of our Services, Forum Hosts (sometimes referred to as "Customer" in other documents) are additionally required to abide by the following use restrictions. 
+
+Forum Hosts must not:
+
+*  Sell Personal Data collected from Consider.it's export data functionality to a third party
+*  Furnish or solicit Customer Data in any way that infringes any Intellectual Property Right, breaks any law (such as privacy or data protection laws), or breaches any other agreement
+*  Furnish or solicit Customer Data subject to Special Data Regulations
+*  Remove proprietary notices from Consider.it
+* Advertise Customer's Forum via unwanted electronic messages such as spam links on newsgroups, email lists, other groups and web sites, and similar unsolicited promotional methods
+*  Post or permit content on Forum Host's Forum that harms the reputation of Consider.it LLC, or leads to unwanted or unfavorable publicity for Consider.it LLC
+* Name the Forum in a manner that misleads your Forum visitors into thinking that you are another person or company
+* Register a forum for the sole purpose of trying to sell the name to someone else
+*  Breach any agreement using Forum Host's Forum
+*  Break the law using Forum Host's Forum
+
+To report a suspected abuse of the Services or a breach of the Terms by a Forum Host, please send written notice to Consider.it at email: [hello@consider.it](mailto:hello@consider.it). 
+
+


### PR DESCRIPTION
Updated legal documents, including:
* a Data Processing Addendum
* documentation of use restrictions
* documentation of security practices
* documentation of subprocessors
* better integrated terms of service and terms for forum hosts
* clearer statement in privacy policy and elsewhere that we won't sell participant data to third-party advertisers or aggregators