### PR TITLE
Authenticity token revisions

### DIFF
--- a/@client/auth/upload_avatar.coffee
+++ b/@client/auth/upload_avatar.coffee
@@ -81,14 +81,13 @@ window.AvatarInput = ReactiveComponent
             @refs.avatar_preview.setAttribute 'src', asset('no_image_preview.png')
 
 window.upload_avatar = ->
-  current_user = fetch '/current_user'
   avatar_file_input = document.getElementById('user_avatar')
   if avatar_file_input?.files.length > 0
     ajax_submit_files_in_form 
       type: 'PUT'
       form: '#user_avatar_form'
       additional_data:  
-        authenticity_token: current_user.csrf
+        authenticity_token: arest.csrf()
         trying_to: 'update_avatar_hack'
       success: (resp) -> 
         # It is important that a user that just submitted a user picture see the picture

--- a/@client/banner.coffee
+++ b/@client/banner.coffee
@@ -1000,10 +1000,9 @@ window.EditBanner = ReactiveComponent
 
   submit_files: (cb) ->
     subdomain = fetch '/subdomain'
-    current_user = fetch '/current_user'
 
     data = 
-      authenticity_token: current_user.csrf
+      authenticity_token: arest.csrf()
     
     if @delete_logo
       data.logo = '*delete*'

--- a/@client/dashboard/all_forums.coffee
+++ b/@client/dashboard/all_forums.coffee
@@ -124,7 +124,7 @@ window.AllYourForums = ReactiveComponent
                     if confirm("Are you sure you want to import this configuration? It will overwrite the configuration of this forum.")
 
                       frm = new FormData()
-                      frm.append "authenticity_token", fetch('/current_user').csrf
+                      frm.append "authenticity_token", arest.csrf()
                       frm.append "subdomain_to_import_configuration", forum.id
 
                       cb = =>
@@ -154,7 +154,7 @@ window.AllYourForums = ReactiveComponent
                     if confirm("Are you sure you want to delete this entire forum? You cannot undo it.")
 
                       frm = new FormData()
-                      frm.append "authenticity_token", fetch('/current_user').csrf
+                      frm.append "authenticity_token", arest.csrf()
                       frm.append "subdomain_to_destroy", forum.id
 
                       cb = =>

--- a/@client/dashboard/edit_profile.coffee
+++ b/@client/dashboard/edit_profile.coffee
@@ -155,7 +155,7 @@ window.EditProfile = ReactiveComponent
                   type: 'delete'
                   form: '#delete_account_form'
                   additional_data: 
-                    authenticity_token: fetch('/current_user').csrf
+                    authenticity_token: arest.csrf()
 
                   success: (resp) =>
                     if resp.length > 0 && JSON.parse(resp)?.error?
@@ -197,7 +197,7 @@ window.EditProfile = ReactiveComponent
                   type: 'delete'
                   form: '#delete_data_form'
                   additional_data: 
-                    authenticity_token: fetch('/current_user').csrf
+                    authenticity_token: arest.csrf()
 
                   success: (resp) =>
                     if resp.length > 0 && JSON.parse(resp)?.error?

--- a/@client/dashboard/forum_settings.coffee
+++ b/@client/dashboard/forum_settings.coffee
@@ -536,7 +536,7 @@ window.ForumSettingsDash = ReactiveComponent
           INPUT 
             type: 'hidden'
             name: 'authenticity_token'
-            value: current_user.csrf
+            value: arest.csrf()
 
 
           INPUT

--- a/@client/dashboard/import_export.coffee
+++ b/@client/dashboard/import_export.coffee
@@ -77,7 +77,7 @@ window.DataDash = ReactiveComponent
         INPUT 
           type: 'hidden'
           name: 'authenticity_token'
-          value: current_user.csrf
+          value: arest.csrf()
 
         H4
           style: 
@@ -226,7 +226,7 @@ window.DataDash = ReactiveComponent
                 form: '#import_data'
                 type: 'POST'
                 additional_data: 
-                  authenticity_token: current_user.csrf
+                  authenticity_token: arest.csrf()
                   trying_to: 'update_avatar_hack'   
                 success: @successful_import_cb
                 error: @failed_import_cb
@@ -278,7 +278,7 @@ window.DataDash = ReactiveComponent
                 if confirm("Are you sure you want to delete all proposals, opinions, and comments on this forum?")
                   
                   frm = new FormData()
-                  frm.append "authenticity_token", current_user.csrf
+                  frm.append "authenticity_token", arest.csrf()
 
                   cb = =>
                     location.reload()
@@ -299,7 +299,7 @@ window.DataDash = ReactiveComponent
                 if confirm("Are you sure you want to entirely delete this forum? In addition to removing all content, the forum and all its configuration will be removed.")
                   
                   frm = new FormData()
-                  frm.append "authenticity_token", current_user.csrf
+                  frm.append "authenticity_token", arest.csrf()
                   frm.append "subdomain_to_destroy", subdomain.id
 
                   cb = =>
@@ -317,7 +317,6 @@ window.DataDash = ReactiveComponent
 
 
   drawArgdownImport: -> 
-    current_user = fetch '/current_user'
     FORM 
       id: 'import_argdown'
       action: '/dashboard/data_import_argdown'
@@ -362,7 +361,7 @@ window.DataDash = ReactiveComponent
             form: '#import_argdown'
             type: 'POST'
             additional_data: 
-              authenticity_token: current_user.csrf
+              authenticity_token: arest.csrf()
               trying_to: 'update_avatar_hack'   
             success: @successful_import_cb
             error: @failed_import_cb
@@ -372,7 +371,6 @@ window.DataDash = ReactiveComponent
 
 
   drawArgdownExport: -> 
-    current_user = fetch '/current_user'
 
     FORM 
       className: "argdown-export"
@@ -397,7 +395,7 @@ window.DataDash = ReactiveComponent
       INPUT 
         type: 'hidden'
         name: 'authenticity_token'
-        value: current_user.csrf
+        value: arest.csrf()
 
       H2
         style: 

--- a/@client/dashboard/moderation.coffee
+++ b/@client/dashboard/moderation.coffee
@@ -759,7 +759,7 @@ DirectMessage = ReactiveComponent
       subject: el.querySelector('#message_subject').value
       body: el.querySelector('#message_body').value 
       sender_mask: @props.sender_mask or fetch('/current_user').name
-      # authenticity_token: fetch('/current_user').csrf
+      # authenticity_token: arest.csrf()
 
     save new_message, =>
       @props.parent.messaging = null

--- a/@client/dashboard/translations.coffee
+++ b/@client/dashboard/translations.coffee
@@ -295,11 +295,17 @@ log_translation_count = (string_id) ->
 
     if Object.keys(translation_uses).length > 0 
       frm = new FormData()
-      frm.append "authenticity_token", fetch('/current_user').csrf
+      frm.append "authenticity_token", arest.csrf()
       frm.append "counts", JSON.stringify(translation_uses)
 
       xhr = new XMLHttpRequest
       xhr.addEventListener 'readystatechange', null, false
+
+      xhr.setRequestHeader('Accept','application/json')
+      xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8")
+      xhr.setRequestHeader('X-CSRF-Token', arest.csrf())
+      xhr.setRequestHeader('X-Requested-With','XMLHttpRequest')
+
       xhr.open 'PUT', '/log_translation_counts', true
       xhr.send frm
 
@@ -894,7 +900,7 @@ updateTranslations = (proposals, cb) ->
   return if window.navigator.userAgent?.indexOf('Prerender') > -1
 
   frm = new FormData()
-  frm.append "authenticity_token", fetch('/current_user').csrf
+  frm.append "authenticity_token", arest.csrf()
   frm.append "proposals", JSON.stringify(proposals)
 
   xhr = new XMLHttpRequest
@@ -909,7 +915,7 @@ updateTranslations = (proposals, cb) ->
 
 deleteTranslationString = (string_id) -> 
   frm = new FormData()
-  frm.append "authenticity_token", fetch('/current_user').csrf
+  frm.append "authenticity_token", arest.csrf()
   frm.append "string_id", string_id
 
   xhr = new XMLHttpRequest
@@ -923,7 +929,7 @@ deleteTranslationString = (string_id) ->
 
 rejectProposals = (proposals) -> 
   frm = new FormData()
-  frm.append "authenticity_token", fetch('/current_user').csrf
+  frm.append "authenticity_token", arest.csrf()
   frm.append "proposals", JSON.stringify(proposals)
 
   xhr = new XMLHttpRequest

--- a/@client/dashboard/translations.coffee
+++ b/@client/dashboard/translations.coffee
@@ -301,11 +301,6 @@ log_translation_count = (string_id) ->
       xhr = new XMLHttpRequest
       xhr.addEventListener 'readystatechange', null, false
 
-      xhr.setRequestHeader('Accept','application/json')
-      xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8")
-      xhr.setRequestHeader('X-CSRF-Token', arest.csrf())
-      xhr.setRequestHeader('X-Requested-With','XMLHttpRequest')
-
       xhr.open 'PUT', '/log_translation_counts', true
       xhr.send frm
 

--- a/@client/edit_proposal.coffee
+++ b/@client/edit_proposal.coffee
@@ -379,13 +379,12 @@ window.EditProposal = ReactiveComponent
 
     save proposal, => 
       if @submit_pic
-        current_user = fetch '/current_user'
         form_to_upload = document.getElementById('proposal_pic_files')
         ajax_submit_files_in_form
           form: '#proposal_pic_files'
           type: 'PUT'
           additional_data: 
-            authenticity_token: current_user.csrf
+            authenticity_token: arest.csrf()
             id: proposal.id
           success: after_save
           error: => 

--- a/@server/controllers/client_error_controller.rb
+++ b/@server/controllers/client_error_controller.rb
@@ -1,5 +1,4 @@
 class ClientErrorController < ApplicationController
-  skip_before_action :verify_authenticity_token
   
   def create
     ## Store this somewhere instead of a puts

--- a/@server/controllers/current_user_controller.rb
+++ b/@server/controllers/current_user_controller.rb
@@ -3,7 +3,6 @@ require 'securerandom'
 
 
 class CurrentUserController < ApplicationController
-  skip_before_action :verify_authenticity_token, :only => [:acs]
 
   # minimum password length
   MIN_PASS = 4

--- a/@server/controllers/log_controller.rb
+++ b/@server/controllers/log_controller.rb
@@ -1,5 +1,4 @@
 class LogController < ApplicationController
-  skip_before_action :verify_authenticity_token
   
   def create
     if session[:search_bot]

--- a/@server/controllers/proposal_controller.rb
+++ b/@server/controllers/proposal_controller.rb
@@ -1,5 +1,4 @@
 class ProposalController < ApplicationController
-  skip_before_action :verify_authenticity_token, :only => :update_images_hack
 
   include Invitations
 

--- a/@server/controllers/subdomain_controller.rb
+++ b/@server/controllers/subdomain_controller.rb
@@ -4,7 +4,6 @@ require 'uri'
 require 'net/http'
 
 class SubdomainController < ApplicationController
-  skip_before_action :verify_authenticity_token, :only => :update_images_hack
   include Invitations
 
   before_action :verify_user, only: [:create]


### PR DESCRIPTION
Significantly reduced the situations where CSRF protection was skipped. Now, it is basically just for server-server API requests.