### PR TITLE
Performance improvements, inspired by (...or guilted into by) a large scale forum

### DIFF
--- a/@client/app.coffee
+++ b/@client/app.coffee
@@ -302,10 +302,7 @@ Root = ReactiveComponent
 
     setTimeout ->
       fetch '/users'
-      if is_a_dialogue_page()
 
-        setTimeout ->
-          fetch '/proposals'
 
     if !fetch('customizations_signature').signature || !app.web_worker
       return  DIV 

--- a/@client/avatar.coffee
+++ b/@client/avatar.coffee
@@ -425,7 +425,10 @@ window.getGroupIcon = (key, color) ->
   group_colored_icons[key]
 
 # Note: this is actually kinda expensive on large forums, in memory and cpu
+icon_cache = {}
 createUserIcon = (fill) ->
+  if fill of icon_cache
+    return icon_cache[fill]
 
   # create a gray-ish avatar for folks who don't have an avatar (or if its broken)
   # Note: this is actually kinda expensive on large forums, in memory and cpu
@@ -436,6 +439,8 @@ createUserIcon = (fill) ->
   ctx.arc(rx, rx, rx, 0, 2 * Math.PI)            
   ctx.fillStyle = fill
   ctx.fill()
+  icon_cache[fill] = canv
+
   canv
 
 window.getCompositeGroupIcon = (key, groups, colors) -> 
@@ -464,7 +469,15 @@ createCompositeGroupIcon = (groups, colors) ->
 
 
 createFallbackIcon = (user) ->
-  user.bg_color ?= hsv2rgb(Math.random() / 5 + .6, Math.random() / 8 + .025, Math.random() / 4 + .4)  # create a gray-ish avatar for folks who don't have an avatar (or if its broken)
+  if !user.bg_color?
+    h = Math.random() / 5 + .6
+    s = Math.random() / 8 + .025
+    v = Math.random() / 4 + .4
+    h = Math.round(h * 15) / 15
+    s = Math.round(s * 15) / 15
+    v = Math.round(v * 15) / 15 
+    user.bg_color = hsv2rgb(h,s,v)  # create a gray-ish avatar for folks who don't have an avatar (or if its broken)
+
   createUserIcon user.bg_color
 
 
@@ -539,8 +552,8 @@ window.LoadAvatars = ReactiveComponent
             @loading_cnt -= 1
             missing_images[user.avatar_file_name] = 1
 
-          setTimeout do(user, pic) -> -> 
-            pic.src = avatarUrl user, 'large'
+          # setTimeout do(user, pic) -> -> 
+          pic.src = avatarUrl user, 'large'
 
       else 
         setTimeout @load, 10   

--- a/@client/edit_list.coffee
+++ b/@client/edit_list.coffee
@@ -103,7 +103,7 @@ window.EditList = ReactiveComponent
                   else 
                     for proposal in list.proposals 
                       proposal.active = false 
-                      save proposal 
+                      save_proposal(proposal)
 
                 customizations = subdomain.customizations
 

--- a/@client/edit_proposal.coffee
+++ b/@client/edit_proposal.coffee
@@ -377,7 +377,7 @@ window.EditProposal = ReactiveComponent
         save @local
 
 
-    save proposal, => 
+    save_proposal proposal, => 
       if @submit_pic
         form_to_upload = document.getElementById('proposal_pic_files')
         ajax_submit_files_in_form
@@ -392,3 +392,13 @@ window.EditProposal = ReactiveComponent
             save @local
       else 
         after_save()
+
+window.save_proposal = (proposal, cb) ->
+  if proposal.opinions
+    stripped_proposal = {}
+    for k,v of proposal
+      if k != 'opinions'
+        stripped_proposal[k] = v
+    proposal = stripped_proposal
+  save proposal, cb
+

--- a/@client/histogram_scores.coffee
+++ b/@client/histogram_scores.coffee
@@ -80,7 +80,7 @@ window.AggregatedHistogram =  ReactiveComponent
           max_weight = cnt
 
         group_weights[group] = cnt
-        group_opinions.push {stance: avg, user: group}
+        group_opinions.push [group, avg]
 
     if min_weight < Infinity && min_weight != max_weight
       for k,v of group_weights

--- a/@client/homepage.coffee
+++ b/@client/homepage.coffee
@@ -102,16 +102,16 @@ window.Homepage = ReactiveComponent
     messages = []
     phase = customization('contribution_phase')
     if phase == 'frozen'
-      messages.push translator "engage.frozen_message", "The forum host has frozen this forum so no changes can be made."
+      messages.push {style: {backgroundColor: '#2e98c0', color: 'white'}, img: 'snowflake.png', label: translator("engage.frozen_message", "The forum host has frozen this forum so no changes can be made.")}
     else if phase == 'ideas-only'
-      messages.push translator "engage.ideas_only_message", "The forum host has set this forum to be ideas only. No opinions for now."
+      messages.push {style: {backgroundColor: '#fcde04', color: 'black'}, img: 'lightning.png', label: translator("engage.ideas_only_message", "The forum host has set this forum to be ideas only. No opinions for now.")}
     else if phase == 'opinions-only'
-      messages.push translator "engage.opinions_only_message", "The forum host has set this forum to be opinions only. No new ideas for now."
+      messages.push {style: {backgroundColor: '#c1ccd0', color: 'black'}, img: 'magnifying_glass.png', label: translator("engage.opinions_only_message", "The forum host has set this forum to be opinions only. No new ideas for now.")}
 
     if customization('anonymize_everything')
-      messages.push translator "engage.anonymize_message", "The forum host has set participation to anonymous, so you won't be able to see the identity of others at this time."
+      messages.push {style: {backgroundColor: '#b88dd1', color: 'black'}, img: 'venetian-mask.png', label: translator("engage.anonymize_message", "The forum host has set participation to anonymous. You won't be able to see the identity of others at this time.")}
     if customization('hide_opinions')
-      messages.push translator "engage.hide_opinions_message", "The forum host has hidden the opinions of other participants."
+      messages.push {style: {backgroundColor: '#faa199', color: 'black'}, img: 'hiding.png', label: translator("engage.hide_opinions_message", "The forum host has hidden the opinions of other participants.")}
 
     DIV 
       key: "homepage_#{subdomain.name}"      
@@ -143,16 +143,30 @@ window.Homepage = ReactiveComponent
               for message in messages
                 DIV 
                   key: message
-                  style: 
+                  style: _.defaults {}, (message.style or {}),
                     backgroundColor: "rgb(184 226 187)"
                     borderRadius: 12
-                    padding: '8px 24px'
+                    padding: '4px 24px'
                     maxWidth: 700
                     margin: "0 auto 16px auto"
                     fontSize: 14
+                    display: 'flex'
+                    alignItems: 'center'
+                    minHeight: 44
                     # textAlign: 'center'
 
-                  message
+                  if message.img 
+                    DIV 
+                      style:
+                        minWidth: 40
+                        paddingRight: 24
+                      IMG 
+                        style: 
+                          maxWidth: 34
+
+                        src: "#{fetch('/application').asset_host}/images/#{message.img}"
+
+                  message.label
 
               if preamble = get_page_preamble()
                 DIV

--- a/@client/opinion_views.coffee
+++ b/@client/opinion_views.coffee
@@ -2000,6 +2000,7 @@ window.participation_timelapse = (step, interval) ->
   first = Infinity
 
   for prop in proposals.proposals
+    prop = fetch(prop)
     for o in prop.opinions
       t = new Date(o.created_at or o.updated_at).getTime()
       if t > last 

--- a/@client/pro_con_widget.coffee
+++ b/@client/pro_con_widget.coffee
@@ -1232,7 +1232,7 @@ window.PointsList = ReactiveComponent
         STYLE 
           dangerouslySetInnerHTML: __html: """
             .point-in-decision-board.with-drop-target .write_#{@props.valence}::before {
-              content: "#{t('or', 'or')}";
+              content: "#{translator('or', 'or')}";
               position: absolute;
               left: -25px;
               top: 5px;

--- a/@client/proposal_sort_and_search.coffee
+++ b/@client/proposal_sort_and_search.coffee
@@ -42,6 +42,7 @@ ApplyFilters = ReactiveComponent
         regexes[filter] = new RegExp filter, 'i'
 
     for proposal in proposals.proposals
+      proposal = fetch proposal
       editor = proposal_editor(proposal)
       if editor 
         editor = fetch(editor).name 
@@ -81,7 +82,7 @@ window.sorted_proposals = (proposals, sort_key, require_force) ->
   sort = fetch 'sort_and_filter_proposals'
   set_default_sort() if !sort.name? 
 
-  proposals = proposals.slice()
+  proposals = (proposals or []).slice()
 
 
   # filter out filtered proposals
@@ -426,7 +427,6 @@ ProposalSort = ReactiveComponent
 
   render : -> 
 
-    proposals = fetch '/proposals' # registering dependency so that we get re-rendered...ApplyFilters is actually dependent
     subdomain = fetch '/subdomain'
 
     return SPAN null if !subdomain.name

--- a/@client/shared.coffee
+++ b/@client/shared.coffee
@@ -141,24 +141,16 @@ if ReactFlipToolkit?
 
 
 window.LIVE_UPDATE_INTERVAL = 3 * 60 * 1000
-
-# live updating
-setInterval ->
-  dependent_keys = []
-  proposals = false 
+window.live_update = ->  
   for key of arest.components_4_key.hash
     if key[0] == '/' && arest.components_4_key.get(key).length > 0 && \
-       !key.match(/\/(current_user|user|opinion|point|subdomain|application|translations)/)
+       !key.match(/\/(current_user|proposal|user|opinion|point|visits|subdomain|application|translations)/)
 
-      if key.match(/\/proposal\/|\/proposals\//)
-        proposals = true 
-      else
-        arest.serverFetch(key)
+      arest.serverFetch(key)
 
-  if proposals 
-    arest.serverFetch('/proposals')
+# live updating
+setInterval live_update, LIVE_UPDATE_INTERVAL
 
-, LIVE_UPDATE_INTERVAL 
 
 
 # To help reduce the chance of clobbering forum customizations when multiple admins have windows open,

--- a/@client/tabs.coffee
+++ b/@client/tabs.coffee
@@ -46,6 +46,7 @@ window.HomepageTabTransition = ReactiveComponent
       default_tab = customization('homepage_default_tab') or get_tabs()[0]?.name or 'Show all'
 
       tab_state_changing = (loc.query_params.tab && loc.query_params.tab != tab_state.active_tab)
+
       if !tab_state.active_tab? || tab_state_changing
 
         if loc.query_params.tab && get_tab(decodeURIComponent(loc.query_params.tab))
@@ -54,20 +55,16 @@ window.HomepageTabTransition = ReactiveComponent
           slug = loc.url.substring(1)
           find_tab = null
 
-          look_for_tab_for_proposal = ->
+          look_for_tab_for_proposal = =>
+            key = "/page/#{slug}"
+            page = arest.cache[key]
+            @checked_times += 1
+            proposal = null
 
-            if arest.cache['/proposals']?.proposals
-              proposal = null
-              @checked_times += 1
+            if page?.proposal
 
-
-              
-              for v in arest.cache['/proposals'].proposals
-                if v.slug == slug
-                  proposal = v
-                  break
-
-              if proposal
+              proposal = fetch(page.proposal)
+              if proposal.name
                 list = get_list_for_proposal proposal
                 tab = get_page_for_list list
 
@@ -77,10 +74,10 @@ window.HomepageTabTransition = ReactiveComponent
                 if find_tab != null
                   clearInterval find_tab
 
-              if @checked_times > 100 && find_tab != null
-                clearInterval find_tab
+            if @checked_times > 100 && find_tab != null
+              clearInterval find_tab
 
-            proposal
+            !!proposal
 
           result = look_for_tab_for_proposal()
           if !result 
@@ -229,7 +226,7 @@ window.delete_tab = (tab_name, skip_confirmation) ->
 window.get_page_for_list = (list_key) -> 
   for page in get_tabs() or []    
     for list in get_lists_for_page(page.name)
-      if list.key == list_key
+      if list == list_key
         return page.name
 
   return null

--- a/@server/controllers/application_controller.rb
+++ b/@server/controllers/application_controller.rb
@@ -315,6 +315,11 @@ protected
       elsif key.match "/page/dashboard"
         noop = 1
 
+      elsif key.match "/list/"
+        response.append(List.all_data(key))
+      elsif key.match '/lists'
+        response.append({key: '/lists', lists: List.list_lists})
+
       elsif key.match "/page/"
         # default to proposal 
         slug = key[6..key.length]
@@ -439,7 +444,11 @@ protected
   def dirty_proposals(real_user)
     if current_subdomain.name != APP_CONFIG[:product_page]
       dirty_key '/proposals'
+      List.list_lists(current_subdomain).each do |lst|
+        dirty_key "/#{lst}"
+      end
     end
+
   end
 
   

--- a/@server/controllers/current_user_controller.rb
+++ b/@server/controllers/current_user_controller.rb
@@ -527,7 +527,7 @@ class CurrentUserController < ApplicationController
     new_participant = current_user.add_to_active_in() == 'added'
     current_user.update_roles_and_permissions
 
-    dirty_key '/proposals'
+    dirty_proposals(user)
     if user.is_admin?
       dirty_key '/subdomain'
       dirty_key '/users'

--- a/@server/controllers/import_data_controller.rb
+++ b/@server/controllers/import_data_controller.rb
@@ -554,7 +554,7 @@ class ImportDataController < ApplicationController
     @argdown = "///// Forum: #{current_subdomain.name} /////"
 
     def get_list_for_proposal(proposal)
-      "list/#{(proposal.cluster or 'Proposals').strip}"
+      "list/#{proposal.get_cluster.strip}"
     end
 
 

--- a/@server/controllers/list_controller.rb
+++ b/@server/controllers/list_controller.rb
@@ -1,0 +1,17 @@
+class ListController < ApplicationController
+  def index
+    authorize!("read proposal", current_subdomain)    
+
+    dirty_key '/lists'
+    render :json => []    
+  end
+
+  def show
+    authorize!("read proposal", current_subdomain)    
+    dirty_key "/list/#{params[:list_name]}"
+    render :json => []
+  end
+
+
+
+end

--- a/@server/controllers/moderation_controller.rb
+++ b/@server/controllers/moderation_controller.rb
@@ -32,11 +32,9 @@ class ModerationController < ApplicationController
         moderation.root_object.point.set_comment_count
       end
 
+      Proposal.clear_cache
     end
 
-    if moderation.moderatable_type.downcase == 'proposal'
-      dirty_key '/proposals'
-    end
 
     dirty_key "/#{moderation.moderatable_type.downcase}/#{moderatable.id}"
     dirty_key "/moderation/#{moderation.id}"

--- a/@server/controllers/opinion_controller.rb
+++ b/@server/controllers/opinion_controller.rb
@@ -55,6 +55,9 @@ class OpinionController < ApplicationController
       :where => proposal.slug
     })
 
+    Proposal.clear_cache
+
+
     original_id = key_id(params[:key])
     result = opinion.as_json
     result['key'] = "/opinion/#{opinion.id}?original_id=#{original_id}"
@@ -114,7 +117,7 @@ class OpinionController < ApplicationController
     end
 
     dirty_key "/proposal/#{proposal.id}"
-    
+    Proposal.clear_cache
 
     render :json => []
 

--- a/@server/controllers/point_controller.rb
+++ b/@server/controllers/point_controller.rb
@@ -79,6 +79,8 @@ class PointController < ApplicationController
 
       dirty_key "/page/#{proposal.slug}"
       dirty_key "/proposal/#{proposal.id}"
+      Proposal.clear_cache
+
       write_to_log({
         :what => 'wrote new point',
         :where => request.fullpath,
@@ -123,6 +125,7 @@ class PointController < ApplicationController
             :where => request.fullpath,
             :details => {:point => "/point/#{point.id}"}
           })
+          Proposal.clear_cache
 
           point.redo_moderation
         end
@@ -150,6 +153,8 @@ class PointController < ApplicationController
       o.recache
       dirty_key "/opinion/#{o.id}"
     end
+
+    Proposal.clear_cache
 
     dirty_key("/page/#{proposal.slug}") #because /points is changed...
     dirty_key("/proposal/#{proposal.id}")

--- a/@server/controllers/proposal_controller.rb
+++ b/@server/controllers/proposal_controller.rb
@@ -63,12 +63,14 @@ class ProposalController < ApplicationController
       result['key'] = "/proposal/#{proposal.id}?original_id=#{original_id}"
 
       dirty_key '/proposals'
+      dirty_key "/list/#{proposal.get_cluster}"
 
       current_user.update_subscription_key(proposal.key, 'watched', :force => false)
       dirty_key '/current_user'
 
       Notifier.notify_parties 'new', proposal
       proposal.notify_moderator
+      Proposal.clear_cache
 
       write_to_log({
         :what => 'created new proposal',
@@ -124,6 +126,7 @@ class ProposalController < ApplicationController
         update_roles(proposal)
 
         proposal.update! updated_fields
+        Proposal.clear_cache
 
         if text_updated
           proposal.redo_moderation
@@ -159,6 +162,8 @@ class ProposalController < ApplicationController
     proposal = Proposal.find(params[:id])
     authorize! 'delete proposal', proposal
     dirty_key '/proposals'
+    dirty_key "/list/#{proposal.get_cluster}"
+    Proposal.clear_cache
     proposal.destroy
     render :json => {:success => true}
   end
@@ -174,6 +179,7 @@ class ProposalController < ApplicationController
     end
     proposal.update attrs
     dirty_key proposal.key
+    Proposal.clear_cache
     render :json => []
   end
 

--- a/@server/controllers/user_controller.rb
+++ b/@server/controllers/user_controller.rb
@@ -42,6 +42,8 @@ class UserController < ApplicationController
     end
 
     dirty_key "/user/#{params[:id]}"
+    Proposal.clear_cache    
+    
     render :json => []
   end
 

--- a/@server/extras/data_exports.rb
+++ b/@server/extras/data_exports.rb
@@ -100,7 +100,7 @@ module DataExports
 
       s = stats opinions.map{|o| o.stance}
 
-      row = [proposal.slug, "https://#{subdomain.url}/#{proposal.slug}", proposal.created_at, (proposal.user ? proposal.user.name : "Unknown"), (proposal.user ? proposal.user.email.gsub('.ghost', '') : 'Unknown'), proposal.name, (proposal.cluster || 'Proposals'), proposal.description, proposal.points.published.count, opinions.count, s[:total].round(2), s[:avg].round(2), s[:std_dev].round(2)]
+      row = [proposal.slug, "https://#{subdomain.url}/#{proposal.slug}", proposal.created_at, (proposal.user ? proposal.user.name : "Unknown"), (proposal.user ? proposal.user.email.gsub('.ghost', '') : 'Unknown'), proposal.name, proposal.get_cluster, proposal.description, proposal.points.published.count, opinions.count, s[:total].round(2), s[:avg].round(2), s[:std_dev].round(2)]
       group_diffs = group_differences proposal 
       group_diffs.each do |diff|
         row.append diff[:ingroup][:count]

--- a/@server/models/list.rb
+++ b/@server/models/list.rb
@@ -1,0 +1,102 @@
+
+
+class List
+
+
+  def self.list_lists(subdomain=nil)
+    subdomain ||= current_subdomain
+
+    all_lists = []
+
+    if subdomain.customizations && subdomain.customizations.has_key?("homepage_tabs") && subdomain.customizations["homepage_tabs"].length > 0
+      tabs = subdomain.customizations["homepage_tabs"]
+
+      # Hack to fix a bug I haven't found where a tab can have a null name
+      idx = tabs.length - 1
+      while idx >= 0
+        if tabs[idx]["name"].nil?
+          tabs.delete_at(idx)
+        end
+        idx -= 1
+      end
+
+      tabs
+    else
+      tabs = nil
+    end
+
+    # Give primacy to specified order of lists in tab config or ordered_list customization
+
+    if tabs
+      tabs.each do |tab|
+        all_lists.concat(tab["lists"].select { |l| l != '*' && l != '*-' })
+      end
+    elsif subdomain.customizations.has_key?('lists')
+      all_lists = subdomain.customizations['lists'].select { |l| l != '*' && l != '*-' }
+    end
+
+    # Lists might also just be defined as a customization, without any proposals in them yet
+    subdomain.customizations.each do |k, v|
+      all_lists.push(k) if k.match(/list\//)
+    end
+
+
+    clusters = ActiveRecord::Base.connection.execute """\
+      SELECT DISTINCT(cluster)
+          FROM proposals 
+          WHERE subdomain_id=#{subdomain.id};
+      """
+
+    clusters.each do |row|
+      clust = row[0] || 'Proposals'
+      all_lists.push "list/#{clust.strip}"
+    end
+
+    all_lists = all_lists.uniq
+
+
+
+    # # Give primacy to specified order of lists in tab config or ordered_list customization
+    # subdomain = fetch('/subdomain')
+    # if get_tabs()
+    #   for tab in get_tabs()
+    #     all_lists = all_lists.concat (l for l in tab.lists when l != '*' && l != '*-')
+    # else if customization 'lists'
+    #   all_lists = (l for l in customization('lists') when l != '*' && l != '*-')
+
+    # # lists might also just be defined as a customization, without any proposals in them yet
+    # subdomain_name = subdomain.name?.toLowerCase()
+    # config = customizations[subdomain_name]
+    # for k,v of config 
+    #   if k.match( /list\// )
+    #     all_lists.push k
+
+    # proposals = fetch '/proposals'
+    # if proposals.proposals
+    #   all_lists = all_lists.concat("list/#{(p.cluster or 'Proposals').trim()}" for p in proposals.proposals)
+
+    # all_lists = _.uniq all_lists
+
+    all_lists 
+
+  end
+
+  def self.all_data(key)
+    proposals = Proposal.summaries[:proposals]
+    cluster = key.split('/')[-1]
+
+    resp = {
+      key: key,
+      proposals: proposals.select {|proposal| (proposal["cluster"] || 'Proposals') == cluster }
+    }
+    resp 
+  end
+
+
+
+end
+
+
+
+
+

--- a/@server/models/opinion.rb
+++ b/@server/models/opinion.rb
@@ -111,6 +111,8 @@ class Opinion < ApplicationRecord
     points_to_exclude = points_already_included.select {|point_id| not points_to_include.include? point_id}
     points_to_add    = points_to_include.select {|p_id| not points_already_included.include? p_id }
 
+    return unless points_to_exclude.length + points_to_exclude.length > 0
+
     # puts("Excluding points #{points_to_exclude}, including points #{points_to_add}")
 
     # Delete goners
@@ -123,6 +125,7 @@ class Opinion < ApplicationRecord
       self.include point_id
     end
 
+    Proposal.clear_cache
   end
 
   def include(point, subdomain = nil)
@@ -155,6 +158,7 @@ class Opinion < ApplicationRecord
 
     point.recache
     self.recache
+    Proposal.clear_cache
 
     dirty_key("/point/#{point.id}")
     dirty_key("/opinion/#{self.id}")
@@ -171,6 +175,7 @@ class Opinion < ApplicationRecord
     inclusion = user.inclusions.find_by_point_id point.id
 
     inclusion.destroy
+    Proposal.clear_cache
     point.recache
     self.recache
   end

--- a/@server/models/point.rb
+++ b/@server/models/point.rb
@@ -148,6 +148,7 @@ class Point < ApplicationRecord
     if changed?
       save(:validate => false) 
       dirty_key "/point/#{self.id}"
+      Proposal.clear_cache      
     end
   end
         

--- a/@server/models/proposal.rb
+++ b/@server/models/proposal.rb
@@ -77,7 +77,24 @@ class Proposal < ApplicationRecord
 
   end
 
+  def self.clear_cache
+    Proposal.clear_cache_points
+    Proposal.clear_cache_proposals
+    Proposal.clear_cache_opinions
+  end
+  def self.clear_cache_opinions
+    Rails.cache.delete "#{current_subdomain.name}-Opinions"
+  end
+  def self.clear_cache_points
+    Rails.cache.delete "#{current_subdomain.name}-Points"
+  end
+  def self.clear_cache_proposals
+    Rails.cache.delete "#{current_subdomain.name}-Proposals"
+  end
+
   def self.summaries(subdomain = nil, all_points = false)
+    start_time = Time.now
+
     subdomain ||= current_subdomain
     
     # Impose access control restrictions for current user
@@ -86,178 +103,249 @@ class Proposal < ApplicationRecord
       proposals = []
     else
 
-      is_admin = current_user.is_admin?(subdomain)
-      registered = current_user.registered
-      user_key = "/user/#{current_user.id}"
       moderation_policy = subdomain.moderation_policy
       asset_host = Rails.application.config.action_controller.asset_host
+      current_user_key = "/user/#{current_user.id}"
 
       ############
       # OPINIONS
-      opinions = ActiveRecord::Base.connection.execute """\
-        SELECT CONCAT('/opinion/', id) as \"key\", point_inclusions, proposal_id, 
-        stance, CONCAT('/user/', user_id) as user, updated_at, published
-            FROM opinions 
-            WHERE subdomain_id=#{subdomain.id};
-        """
-      opinions_by_proposal = {}
+
+      opinions_key = "#{subdomain.name}-Opinions"
+      opinions_by_proposal = Rails.cache.fetch(opinions_key, {expires_in: 29.minutes} ) do 
+        opinions = ActiveRecord::Base.connection.execute """\
+          SELECT CONCAT('/opinion/', id) as \"key\", point_inclusions, proposal_id, 
+          stance, CONCAT('/user/', user_id) as user, updated_at
+              FROM opinions 
+              WHERE subdomain_id=#{subdomain.id};
+          """
+        by_proposal = {}
+
+        opinions.each(:as => :hash) do |o|
+          proposal_id = o["proposal_id"].to_i
+
+          o.delete("proposal_id")
+
+          if o["point_inclusions"] && o["point_inclusions"] != '[]'
+            o["point_inclusions"] = Oj.load(o["point_inclusions"]).map! {|p| "/point/#{p}"}
+          else
+            o.delete "point_inclusions"
+          end 
+
+          by_proposal[proposal_id] ||= []          
+          by_proposal[proposal_id].push o 
+        end 
+        JSON.dump by_proposal
+      end
+
+      opinions_by_proposal = JSON.parse opinions_by_proposal
+
       your_opinions_by_proposal = {}
 
-      opinions.each(:as => :hash) do |o|
-        next if o["published"] == 0 && o["user"] != user_key
+      if current_user.registered
+        your_opinions = ActiveRecord::Base.connection.execute """\
+          SELECT CONCAT('/opinion/', id) as \"key\", point_inclusions, proposal_id, 
+          stance, CONCAT('/user/', user_id) as user, updated_at
+              FROM opinions 
+              WHERE subdomain_id=#{subdomain.id} AND user_id=#{current_user.id};
+          """
 
-        proposal_id = o["proposal_id"]
-        if !opinions_by_proposal.has_key?(proposal_id)
-          opinions_by_proposal[proposal_id] = []
-        end
+        your_opinions.each(:as => :hash) do |o|
+          proposal_id = o["proposal_id"]
+          o.delete("proposal_id")
 
-        o.delete("published")
-        o.delete("proposal_id")
+          if o["point_inclusions"] && o["point_inclusions"] != '[]'
+            o["point_inclusions"] = Oj.load(o["point_inclusions"]).map! {|p| "/point/#{p}"}
+          else
+            o.delete "point_inclusions"
+          end 
 
-        if o["point_inclusions"] && o["point_inclusions"] != '[]'
-          o["point_inclusions"] = Oj.load(o["point_inclusions"]).map! {|p| "/point/#{p}"}
-        else
-          o.delete "point_inclusions"
-        end 
-
-        opinions_by_proposal[proposal_id].push o 
-
-        if o["user"] == user_key
-          # o["proposal"] = "/proposal/#{proposal_id}"
           your_opinions_by_proposal[proposal_id] = o
         end
-      end 
+      end
 
+      
       ############
       # POINTS
 
-      if subdomain.moderation_policy == 1
-        moderation_status_check = 'moderation_status=1'
-      else 
-        moderation_status_check = '(moderation_status IS NULL OR moderation_status=1)'
-      end
+      points_key = "#{subdomain.name}-Points"
+      moderation_status_check = "(moderation_status is NULL OR moderation_status != 0)"      
 
-      ppoints = ActiveRecord::Base.connection.execute """\
-        SELECT comment_count, created_at, updated_at, id, includers, is_pro, nutshell, 
-               proposal_id, published, text, user_id, hide_name, last_inclusion, subdomain_id
-            FROM points 
-            WHERE subdomain_id=#{subdomain.id} AND
-                  published=1 AND
-                  #{moderation_status_check};
-        """
+      pre_points_by_proposal = Rails.cache.fetch(points_key, expires_in: 59.minutes ) do 
+        # if subdomain.moderation_policy == 1
+        #   moderation_status_check = 'moderation_status=1'
+        # else 
+        #   moderation_status_check = '(moderation_status IS NULL OR moderation_status=1)'
+        # end
 
-      points_by_proposal = {}
-      ppoints.each do |pnt|
-        proposal_id = pnt[7]
+        ppoints = ActiveRecord::Base.connection.execute """\
+          SELECT comment_count, created_at, updated_at, id, includers, is_pro, nutshell, 
+                 proposal_id, published, text, user_id, hide_name, last_inclusion, subdomain_id, moderation_status
+              FROM points 
+              WHERE subdomain_id=#{subdomain.id} AND
+                    published=1 AND
+                    #{moderation_status_check};
+          """
 
-        ppnt = {
-          "id" => pnt[3],
-          "comment_count" => pnt[0],
-          "created_at" => pnt[1], 
-          "updated_at" => pnt[2], 
-          "key" => "/point/#{pnt[3]}",
-          "includers" => pnt[4],
-          "is_pro" => pnt[5] == 1, 
-          "nutshell" => pnt[6],
-          "proposal" => "/proposal/#{pnt[7]}",
-          "published" => pnt[8] == 1,
-          "text" => pnt[9],
-          "user" => "/user/#{pnt[10]}",
-          "hide_name" => pnt[11] == 1,
-          "last_inclusion" => pnt[12],
-          "subdomain_id" => pnt[13]
-        }
+        by_proposal = {}
+        ppoints.each(:as => :hash) do |pnt|
+          proposal_id = pnt["proposal_id"]
 
-
-        if ppnt["includers"]
-          ppnt["includers"] = JSON.load(ppnt["includers"]).map! {|u| u.is_a?(Integer) ? "/user/#{u}" : u}
-        else 
-          ppnt["includers"] = []
-        end 
+          ppnt = {
+            "id" => pnt["id"],
+            "comment_count" => pnt["comment_count"],
+            "created_at" => pnt["created_at"], 
+            "updated_at" => pnt["updated_at"], 
+            "key" => "/point/#{pnt["id"]}",
+            "includers" => pnt["includers"],
+            "is_pro" => pnt["is_pro"] == 1, 
+            "nutshell" => pnt["nutshell"],
+            "proposal" => "/proposal/#{pnt["proposal_id"]}",
+            "published" => pnt["published"] == 1,
+            "text" => pnt["text"],
+            "user" => "/user/#{pnt["user_id"]}",
+            "hide_name" => pnt["hide_name"] == 1,
+            "last_inclusion" => pnt["last_inclusion"],
+            "subdomain_id" => pnt["subdomain_id"],
+            "moderation_status" => pnt["moderation_status"]
+          }
 
 
-        # If anonymous, hide user id
-        if ppnt["hide_name"]
-          ppnt["includers"].map! {|u| u == ppnt["user"] ? "/user/-1" : u }
-
-          if current_user.nil? || current_user.id != pnt[10]
-            ppnt["user"] = "/user/-1"
+          if ppnt["includers"]
+            ppnt["includers"] = JSON.load(ppnt["includers"]).map! {|u| u.is_a?(Integer) ? "/user/#{u}" : u}
+          else 
+            ppnt["includers"] = []
           end 
 
+          by_proposal[proposal_id] ||= []
+          by_proposal[proposal_id].push ppnt
+
         end
-
-
-        points_by_proposal[proposal_id] ||= []
-        points_by_proposal[proposal_id].push ppnt
-
+        JSON.dump by_proposal
       end
 
+      pre_points_by_proposal = JSON.parse pre_points_by_proposal
+
+      points_by_proposal = {}
+      
+      pre_points_by_proposal.each do |proposal_id, points|
+        points_by_proposal[proposal_id] = []
+        points.each do |ppnt|
+          # passes moderation
+          passes = ppnt['moderation_status'] == 1 || ppnt['user'] == current_user_key
+
+          if subdomain.moderation_policy != 1
+            passes ||= ppnt['moderation_status'] == nil
+          end
+          next if !passes
+
+          pnt = ppnt.deep_dup
+          pnt.delete("moderation_status")
+
+          # If anonymous, hide user id
+          if pnt["hide_name"]
+            pnt["includers"].map! {|u| u == pnt["user"] ? "/user/-1" : u }
+
+            if current_user.nil? || current_user.id != pnt[10]
+              pnt["user"] = "/user/-1"
+            end 
+          end
+          points_by_proposal[proposal_id].push pnt
+        end
+      end
 
       #################
       # PROPOSALS
-      if subdomain.moderation_policy == 1
-        moderation_status_check = "(moderation_status=1 OR user_id=#{current_user.id})"
-      else 
-        moderation_status_check = "(moderation_status IS NULL OR moderation_status=1 OR user_id=#{current_user.id})"
+      proposals_key = "#{subdomain.name}-Proposals"
+      moderation_status_check = "(moderation_status is NULL OR moderation_status != 0)"      
+      
+      json_proposals = Rails.cache.fetch(proposals_key, expires_in: 93.minutes ) do 
+        pp "CACHING PROPOSALS"
+
+        
+
+        qry = """\
+          SELECT id, concat('/proposal/', id) as \"key\", slug, cluster, concat('/user/', user_id) as user, created_at, 
+                 updated_at, name, 
+                 description, active, published, subdomain_id, json,
+                 moderation_status, pic_file_name, banner_file_name, roles
+              FROM proposals 
+              WHERE subdomain_id=#{subdomain.id} AND
+                    hide_on_homepage = false AND
+                    #{moderation_status_check};
+          """
+
+
+        pproposals = ActiveRecord::Base.connection.execute qry
+
+        j_proposals = []
+        pproposals.each(:as => :hash) do |p|
+          if p["json"]
+            p["json"] = JSON.load(p["json"])
+          else 
+            p["json"] = {}
+          end
+
+          if moderation_policy == 1 && !p["moderation_status"] 
+            p["under_review"] = true
+          end
+
+          if p["pic_file_name"]
+            p['pic'] = "#{asset_host}/system/pics/#{p["id"]}/square/#{p["pic_file_name"]}"
+          end
+
+          if p["banner_file_name"]
+            p['banner'] = "#{asset_host}/system/banners/#{p["id"]}/original/#{p["banner_file_name"]}"
+          end
+
+          p.delete("banner_file_name")          
+          p.delete("pic_file_name")
+
+          p["active"] = p["active"] == 1
+          p["published"] = p["published"] == 1
+
+          j_proposals.push p
+        end
+        JSON.dump j_proposals
       end
+      json_proposals = JSON.parse json_proposals
 
-      pproposals = ActiveRecord::Base.connection.execute """\
-        SELECT id, concat('/proposal/', id) as \"key\", slug, cluster, concat('/user/', user_id) as user, created_at, 
-               updated_at, name, 
-               description, active, published, subdomain_id, json,
-               moderation_status, pic_file_name, banner_file_name, roles
-            FROM proposals 
-            WHERE subdomain_id=#{subdomain.id} AND
-                  hide_on_homepage = false AND
-                  #{moderation_status_check};
-        """
+      proposals = []
 
-      json_proposals = []
-      pproposals.each(:as => :hash) do |p|
-        if p["json"]
-          p["json"] = JSON.load(p["json"])
-        else 
-          p["json"] = {}
+      is_admin = current_user.is_admin?(subdomain)
+      registered = current_user.registered
+      user_key = "/user/#{current_user.id}"
+
+
+      json_proposals.each do |p|
+        proposal = p.deep_dup
+
+        passes = proposal['moderation_status'] == 1 || proposal['user'] == current_user_key
+
+        if subdomain.moderation_policy != 1
+          passes ||= proposal['moderation_status'] == nil
         end
 
-        if moderation_policy == 1 && !p["moderation_status"] # TODO: is p[14] nil or "null"?
-          p["under_review"] = true
-        end
+        next if !passes
 
-        if p["pic_file_name"]
-          p['pic'] = "#{asset_host}/system/pics/#{p["id"]}/square/#{p["pic_file_name"]}"
-        end
-
-        if p["banner_file_name"]
-          p['banner'] = "#{asset_host}/system/banners/#{p["id"]}/original/#{p["banner_file_name"]}"
-        end
-
-        p.delete("banner_file_name")          
-        p.delete("pic_file_name")
-        p.delete("moderation_status")
-
-        p["active"] = p["active"] == 1
-        p["published"] = p["published"] == 1
-
-        roles = Oj.load(p["roles"])
+        roles = Oj.load(proposal["roles"])
 
         # this logic taken from 'update proposal' permission, so those need to be kept in sync
         can_update = registered && (is_admin || Permissions::matchEmail(Proposal.user_roles(roles)['editor'], current_user))
-        p['roles'] = Proposal.user_roles roles, !can_update
+        proposal['roles'] = Proposal.user_roles roles, !can_update
         if can_update
-          p['invitations'] = nil
+          proposal['invitations'] = nil
         end
 
-        opinions = opinions_by_proposal[p["id"]] || []
-        p['opinions'] = opinions
+        opinions = opinions_by_proposal["#{proposal["id"]}"] || []
+        proposal['opinions'] = opinions
 
         # Find an existing opinion for this user
-        your_opinion = your_opinions_by_proposal.fetch(p["id"], nil)
+        your_opinion = your_opinions_by_proposal.fetch(proposal["id"], nil)
 
         if your_opinion
-          p['your_opinion'] = your_opinion 
+          proposal['your_opinion'] = your_opinion 
         else 
-          p['your_opinion'] = {
+          proposal['your_opinion'] = {
             stance: 0,
             user: user_key,
             point_inclusions: [],
@@ -266,24 +354,24 @@ class Proposal < ApplicationRecord
           }
         end
 
-        pnts = points_by_proposal.fetch(p["id"], [])
+        pnts = points_by_proposal.fetch(proposal["id"], [])
 
         if all_points
-          p[:points] = pnts
+          proposal[:points] = pnts
         end 
 
         pnts_with_inclusions = pnts.select{ |pnt| pnt["includers"].length > 0 }
 
-        p['point_count'] = pnts_with_inclusions.length
-        json_proposals.push p
+        proposal['point_count'] = pnts_with_inclusions.length
+        proposals.push proposal
       end
-
     end
 
+    Rails.logger.info("Code execution took: #{Time.now - start_time} seconds")
 
     proposals_obj = {
       key: '/proposals',
-      proposals: json_proposals
+      proposals: proposals # .map {|p| p["key"]}
     }
 
     proposals_obj
@@ -291,6 +379,7 @@ class Proposal < ApplicationRecord
 
 
   end
+
 
 
   def full_data
@@ -510,6 +599,10 @@ class Proposal < ApplicationRecord
       my_title
     end
     
+  end
+
+  def get_cluster
+    self.cluster or 'Proposals'
   end
 
 

--- a/@server/models/subdomain.rb
+++ b/@server/models/subdomain.rb
@@ -184,6 +184,7 @@ class Subdomain < ApplicationRecord
     self.opinions.destroy_all
     self.points.destroy_all
     self.comments.destroy_all
+    Proposal.clear_cache
   end
 
   def import_from_argdown(argdown, active_user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,9 @@ Rails.application.routes.draw do
 
   match '/user/:id' => 'user#update', :via => [:put]
 
+  get '/lists' => 'list#index'
+  get '/list/:list_name' => 'list#show'
+
   resources :proposal
   get '/proposals' => 'proposal#index'
   get '/all_comments' => 'comment#all_for_subdomain'

--- a/db/migrate/20230426220818_drophistocachefromproposals.rb
+++ b/db/migrate/20230426220818_drophistocachefromproposals.rb
@@ -1,0 +1,5 @@
+class Drophistocachefromproposals < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :proposals, :histocache 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_03_235919) do
+ActiveRecord::Schema.define(version: 2023_04_26_220818) do
 
   create_table "ahoy_events", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "subdomain_id"
@@ -208,7 +208,6 @@ ActiveRecord::Schema.define(version: 2023_03_03_235919) do
     t.string "seo_keywords"
     t.string "cluster"
     t.json "roles"
-    t.json "histocache"
     t.json "json"
     t.string "pic_file_name"
     t.string "pic_content_type"


### PR DESCRIPTION
Two structural performance improvements: 

1) The main performance hangup was data transfer size. I improved the situation by, instead of fetching all proposal + opinion data all at once via fetch('/proposals'), now data can be fetched list-by-list (each focus). This allows us to be much more selective about which data to download. This will also allow for better responsivity for longer standing phased forums. Data from archival tabs won't have to be fetched. 

2) The server was generating all proposal + opinion + pro/con data for a particular user *every time someone accessed the forum*. This led to significant lag and unnecessary computational effort, especially as forums increase in size. I improved the situation by caching proposal, opinion, and point data, and then post processing it for user-specific filtering on each request (see proposal.rb). I'm not a big fan of all the calls to Proposal.clear_cache sprinkled throughout the server code in order to invalidate the cache when some change is made, but it is what it is.

Client-side performance improvements include: 
  - only run the histogram layout algorithm (and renderer) for histograms when it is in the viewport
  - don't generate a custom icon for users who didn't set an avatar. Instead, choose from a small number of icons (this made the biggest impact)

Client-side experience improvements include:
  - more use of loading indicators, especially for histograms whose data is being fetched and/or laid out