### PR TITLE
Add dialog to screenshot a proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "yamljs": "^0.2.1",
     "webpack": "1.11.0",
     "chunk-manifest-webpack-plugin": "0.0.1",
-    "compression-webpack-plugin": "0.2.0"
+    "compression-webpack-plugin": "0.2.0",
+    "html-to-image": "1.11.11"
   }
 }


### PR DESCRIPTION
When the proposal is expanded, an extra button is added next to edit and delete buttons, which opens the screenshot dialog.  The dialog offers options to choose which part of the proposal to screenshot (opinions vs reasons).  The dialog also has buttons to copy the screenshot or the URL to clipboard.  (Copy to clipboard is not well tested, because only https and localhost domains have access to clipboard API.)
