### PR TITLE
Date display fix

### DIFF
--- a/@client/shared.coffee
+++ b/@client/shared.coffee
@@ -362,7 +362,7 @@ window.prettyDate = (time) ->
   return if isNaN(day_diff) || day_diff < 0
 
   if subdomain.lang != 'en'
-    return "#{date.getMonth() + 1}/#{date.getDate() + 1}/#{date.getFullYear()}" 
+    return "#{date.getMonth() + 1}/#{date.getDate()}/#{date.getFullYear()}" 
 
   r = day_diff == 0 && (
     diff < 60 && "just now" || 


### PR DESCRIPTION
Javascript Date-object day-of-month is 1-based, does not need to add 1, per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate