### PR TITLE
Add forum setting to permanently anonymize

### DIFF
--- a/@client/dashboard/forum_settings.coffee
+++ b/@client/dashboard/forum_settings.coffee
@@ -243,6 +243,8 @@ window.ForumSettingsDash = ReactiveComponent
 
       DIV 
         className: 'input_group checkbox'
+        style: 
+          paddingLeft: 70
         
         LABEL 
           className: 'toggle_switch' + ( if allow_change_perm_anon  then ''  else ' disabled' )

--- a/@client/dashboard/forum_settings.coffee
+++ b/@client/dashboard/forum_settings.coffee
@@ -50,6 +50,10 @@ window.styles += """
     margin-top: 6px;
   }
 
+  .FORUM_SETTINGS .input_group.checkbox .toggle_switch.disabled{
+    opacity: 0.3;
+  }
+
   """
 
 window.ForumSettingsDash = ReactiveComponent
@@ -65,6 +69,8 @@ window.ForumSettingsDash = ReactiveComponent
 
     return SPAN null if !subdomain.name
 
+    allow_change_anon = not subdomain.customizations.anonymize_permanently
+    allow_change_perm_anon = subdomain.customizations.anonymize_everything and (not subdomain.customizations.anonymize_permanently)
 
 
     DIV 
@@ -202,13 +208,14 @@ window.ForumSettingsDash = ReactiveComponent
         className: 'input_group checkbox'
         
         LABEL 
-          className: 'toggle_switch'
+          className: 'toggle_switch' + ( if allow_change_anon  then ''  else ' disabled' )
 
           INPUT 
             id: 'anonymize_everything'
             type: 'checkbox'
             name: 'anonymize_everything'
             defaultChecked: customization('anonymize_everything')
+            disabled: not allow_change_anon
             onChange: (ev) -> 
               subdomain.customizations ||= {}
               subdomain.customizations.anonymize_everything = ev.target.checked
@@ -229,6 +236,67 @@ window.ForumSettingsDash = ReactiveComponent
             className: 'explanation'
 
             "The authors of opinions, points, proposals, and comments will be hidden. Participants still need to be registered. The real identity of authors will still be accessible via the data export."
+
+
+      ########################
+      # Anonymize permanently
+
+      DIV 
+        className: 'input_group checkbox'
+        
+        LABEL 
+          className: 'toggle_switch' + ( if allow_change_perm_anon  then ''  else ' disabled' )
+          onClick: (ev) -> 
+            # Enforce disabled condition
+            if not allow_change_perm_anon
+              ev.stopPropagation()
+              ev.preventDefault()
+              return
+            # Receives click-events from both label and span, which should be deduplicated to prevent redundant confirmation-dialogs
+            # Deduplicate by time between confirm() finish and second event.
+            #   Deduplicating by time between events fails, because second event time is delayed until confirm() response.
+            #   Deduplicating by target is fragile, assumes specific target order.
+            #   Deduplicating by event X/Y coordinates would fail for accessibility cases like keyboard control.
+            # If user just ok'd to confirm change... this is a duplicate click event, do not re-prompt to confirm
+            now = new Date()
+            confirmed = @lastConfirmTime and ( now - @lastConfirmTime < 100 )
+            if confirmed
+              return confirmed
+            # Prompt user for confirmation, and stop click-events if user cancels change
+            confirmed = confirm( 'User identities will be gone forever. Are you certain?' )
+            if confirmed
+              @lastConfirmTime = new Date()
+            else
+              ev.stopPropagation()
+              ev.preventDefault()
+
+          INPUT 
+            id: 'anonymize_permanently'
+            type: 'checkbox'
+            name: 'anonymize_permanently'
+            defaultChecked: customization('anonymize_permanently')
+            disabled: not allow_change_perm_anon
+            onChange: (ev) -> 
+              subdomain.customizations ||= {}
+              if ev.target.checked
+                subdomain.customizations.anonymize_everything = true
+              subdomain.customizations.anonymize_permanently = ev.target.checked
+              save subdomain, ->
+                arest.serverFetch('/users') # anonymity may have changed, so force a refetch
+          
+          SPAN 
+            className: 'toggle_switch_circle'
+
+        LABEL 
+          className: 'indented'
+          htmlFor: 'anonymize_permanently'
+          B null,
+            'Anonymize permanently.'
+          
+          DIV 
+            className: 'explanation'
+            "Anonymization will become irreversible. Data export will not reveal the real identity of authors."
+
 
       ########################
       # HIDE OPINIONS OF EVERYONE

--- a/@client/dashboard/forum_settings.coffee
+++ b/@client/dashboard/forum_settings.coffee
@@ -263,7 +263,7 @@ window.ForumSettingsDash = ReactiveComponent
             if confirmed
               return confirmed
             # Prompt user for confirmation, and stop click-events if user cancels change
-            confirmed = confirm( 'User identities will be gone forever. Are you certain?' )
+            confirmed = confirm( 'This makes anonymization of this forum permanent. You will not be able to revert. Are you certain?' )
             if confirmed
               @lastConfirmTime = new Date()
             else
@@ -295,7 +295,7 @@ window.ForumSettingsDash = ReactiveComponent
           
           DIV 
             className: 'explanation'
-            "Anonymization will become irreversible. Data export will not reveal the real identity of authors."
+            "Anonymization will become irreversible. You will never see the identities of participants. Data export will not reveal the real identity of authors."
 
 
       ########################

--- a/@client/dashboard/intake_questions.coffee
+++ b/@client/dashboard/intake_questions.coffee
@@ -103,6 +103,38 @@ window.IntakeQuestions = ReactiveComponent
 
 
 
+      if subdomain.customizations.anonymize_permanently && !subdomain.customizations.anonymization_safe_opinion_filters
+        message = 
+          style: {backgroundColor: '#d1d08d', color: 'black'}
+          img: 'venetian-mask.png' 
+          label: "You have permanently set participation to anonymous. The answers to any questions you ask here will not be available to you. If the questions you are asking are not personally revealing for participants, please contact help@consider.it to whitelist your questions."
+        DIV 
+          key: message
+          style: _.defaults {}, (message.style or {}),
+            backgroundColor: "rgb(184 226 187)"
+            borderRadius: 12
+            padding: '4px 24px'
+            maxWidth: 700
+            margin: "0 auto 16px auto"
+            fontSize: 14
+            display: 'flex'
+            alignItems: 'center'
+            minHeight: 44
+            # textAlign: 'center'
+
+          if message.img 
+            DIV 
+              style:
+                minWidth: 40
+                paddingRight: 24
+              IMG 
+                style: 
+                  maxWidth: 34
+
+                src: "#{fetch('/application').asset_host}/images/#{message.img}"
+          message.label
+
+
       P null,
         """
           Sign-up questions enable you to collect information from new participants during account 

--- a/@client/homepage.coffee
+++ b/@client/homepage.coffee
@@ -109,7 +109,11 @@ window.Homepage = ReactiveComponent
       messages.push {style: {backgroundColor: '#c1ccd0', color: 'black'}, img: 'magnifying_glass.png', label: translator("engage.opinions_only_message", "The forum host has set this forum to be opinions only. No new ideas for now.")}
 
     if customization('anonymize_everything')
-      messages.push {style: {backgroundColor: '#b88dd1', color: 'black'}, img: 'venetian-mask.png', label: translator("engage.anonymize_message", "The forum host has set participation to anonymous. You won't be able to see the identity of others at this time.")}
+      if customization('anonymize_permanently')
+        messages.push {style: {backgroundColor: '#d1d08d', color: 'black'}, img: 'venetian-mask.png', label: translator("engage.anonymize_permanently_message", "The forum host has permanently set participation to anonymous. No one, including the host, will ever have access to the identity of participants.")}
+      else 
+        messages.push {style: {backgroundColor: '#b88dd1', color: 'black'}, img: 'venetian-mask.png', label: translator("engage.anonymize_message", "The forum host has set participation to anonymous. You won't be able to see the identity of others at this time. However, the host may reveal identity later.")}
+
     if customization('hide_opinions')
       messages.push {style: {backgroundColor: '#faa199', color: 'black'}, img: 'hiding.png', label: translator("engage.hide_opinions_message", "The forum host has hidden the opinions of other participants.")}
 


### PR DESCRIPTION
This change adds another forum setting toggle to make anonymization permanent.  There are constraints between the anonymize and permanent toggles: 
* Anonymize must be on before permanent can be on
* Once permanent is on, neither toggle can change

An alternative user interface could be drop-down menu holding the three possible anonymization states: {off, temporary, permanent}. But adding a new toggle was chosen for consistency with the current UI and data model.
