### PR TITLE
Add follow-up tag to proposals

### DIFF
--- a/db/migrate/20230606163937_add_follow_up_to_proposals.rb
+++ b/db/migrate/20230606163937_add_follow_up_to_proposals.rb
@@ -1,0 +1,5 @@
+class AddFollowUpToProposals < ActiveRecord::Migration[6.1]
+  def change
+    add_column :proposals, :follow_up, :string, limit: 10
+  end
+end

--- a/db/migrate/20230606164729_add_follow_up_url_to_proposals.rb
+++ b/db/migrate/20230606164729_add_follow_up_url_to_proposals.rb
@@ -1,0 +1,5 @@
+class AddFollowUpUrlToProposals < ActiveRecord::Migration[6.1]
+  def change
+    add_column :proposals, :follow_up_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_26_220818) do
+ActiveRecord::Schema.define(version: 2023_06_06_164729) do
 
   create_table "ahoy_events", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "subdomain_id"
@@ -217,6 +217,8 @@ ActiveRecord::Schema.define(version: 2023_04_26_220818) do
     t.string "banner_content_type"
     t.integer "banner_file_size"
     t.datetime "banner_updated_at"
+    t.string "follow_up", limit: 10
+    t.text "follow_up_url"
     t.index ["subdomain_id", "active"], name: "select_proposal_by_active"
     t.index ["subdomain_id", "id"], name: "select_proposal"
     t.index ["subdomain_id", "slug"], name: "select_proposal_by_long_id"


### PR DESCRIPTION
Adds a follow-up tag to the meta-data under proposal-title.  Hosts can click the tag to set follow-up status and a link to more info.  Participants only see the tag if status is set, and can click the tag to follow the link to more info.