### PR TITLE
Update Gemfile: remove tomoto

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ gem 'rubyzip'
 
 #####################
 # For topic modeling
-gem "tomoto"
 gem "lemmatizer"
 
 #############


### PR DESCRIPTION
Tomoto does not build, and is not currently used.  Alternatively, we could just comment the dependency, if it is occasionally used for development.