### PR TITLE
Update list.coffee get_all_lists() to return non-null

### DIFF
--- a/@client/list.coffee
+++ b/@client/list.coffee
@@ -1191,7 +1191,7 @@ category_value = (list_key, fresh, subdomain) ->
 
 
 window.get_all_lists = ->
-  fetch('/lists').lists
+  fetch('/lists').lists or []
 
 window.get_all_lists_not_configured_for_a_page = ->
   lists = fetch('/lists').lists or []


### PR DESCRIPTION
get_all_lists() can cause errors when fetch('/lists') returns null